### PR TITLE
Update asset-test.yml to use python 3.11 in macos

### DIFF
--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -40,6 +40,11 @@ jobs:
         with:
           # NOTE: Hard Coded Node Version
           node-version: '18.16.1'
+      # TODO: try default python again in the future 
+      - name: Use Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
       - run: yarn setup
       - run: yarn lint
       # TODO: Ideally we'd be able to at least run unit tests that don't require docker.

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           # NOTE: Hard Coded Node Version
           node-version: '18.16.1'
+      # NOTE: Prevent python 3.12 breaking node-gyp installations in the kafka asset
       # TODO: try default python again in the future 
       - name: Use Python 3.11
         uses: actions/setup-python@v4


### PR DESCRIPTION
The GA runner image updated python to 3.12, which deprecated `distutils` causing node-gyp to break.