### PR TITLE
update node 16 and 18 versions

### DIFF
--- a/.github/workflows/asset-build-and-publish.yml
+++ b/.github/workflows/asset-build-and-publish.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         # NOTE: Hard Coded Node Version array, should match array in test-asset.yml
-        node-version: [14.21.3, 16.20.1, 18.16.1]
+        node-version: [14.21.3, 16.20.2, 18.18.2]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           # NOTE: Hard Coded Node Version
-          node-version: '18.16.1'
+          node-version: '18.18.2'
           registry-url: 'https://registry.npmjs.org'
       - run: yarn setup
       - run: ./scripts/publish.sh

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         # NOTE: Hard Coded Node Version array, should match array in build-and-publish-asset.yml
-        node-version: [14.21.3, 16.20.1, 18.16.1]
+        node-version: [14.21.3, 16.20.2, 18.18.2]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
@@ -39,7 +39,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           # NOTE: Hard Coded Node Version
-          node-version: '18.16.1'
+          node-version: '18.18.2'
       # NOTE: Prevent python 3.12 breaking node-gyp installations in the kafka asset
       # TODO: try default python again in the future 
       - name: Use Python 3.11


### PR DESCRIPTION
I have updated all places where node 16 and 18 are referenced to following versions:
- `node 18.18.2`
- `node 16.20.2`

This addresses an issue in the Teraslice repo [here](https://github.com/terascope/teraslice/issues/3459)