### PR TITLE
Pin teraslice-cli version to 0.62.0 temporarily

### DIFF
--- a/.github/workflows/asset-build-and-publish.yml
+++ b/.github/workflows/asset-build-and-publish.yml
@@ -26,7 +26,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: yarn setup
       - run: yarn build
-      - run: yarn global add teraslice-cli
+      - run: yarn global add teraslice-cli@0.62.0
       - run: teraslice-cli -v
       - run: teraslice-cli assets build
       - run: ls -l ./build/

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -26,7 +26,7 @@ jobs:
       - run: yarn setup
       - run: yarn lint
       - run: yarn test:all
-      - run: yarn global add teraslice-cli
+      - run: yarn global add teraslice-cli@0.62.0
       - run: teraslice-cli -v
       - run: teraslice-cli assets build
       - run: ls -l build/
@@ -50,7 +50,7 @@ jobs:
       - run: yarn lint
       # TODO: Ideally we'd be able to at least run unit tests that don't require docker.
       #- run: yarn test:all
-      - run: yarn global add teraslice-cli
+      - run: yarn global add teraslice-cli@0.62.0
       - run: teraslice-cli -v
       - run: teraslice-cli assets build
       - run: ls -l build/


### PR DESCRIPTION
There is an issue in `teraslice-cli@1.0.0` that is causing `teraslice-cli assets build` to fail. We will pin at the previous version, 0.62.0, until `teraslice-cli` is updated.