### PR TITLE
Unpin teraslice-cli version

### DIFF
--- a/.github/workflows/asset-build-and-publish.yml
+++ b/.github/workflows/asset-build-and-publish.yml
@@ -26,7 +26,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: yarn setup
       - run: yarn build
-      - run: yarn global add teraslice-cli@0.62.0
+      - run: yarn global add teraslice-cli
       - run: teraslice-cli -v
       - run: teraslice-cli assets build
       - run: ls -l ./build/

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -26,7 +26,7 @@ jobs:
       - run: yarn setup
       - run: yarn lint
       - run: yarn test:all
-      - run: yarn global add teraslice-cli@0.62.0
+      - run: yarn global add teraslice-cli
       - run: teraslice-cli -v
       - run: teraslice-cli assets build
       - run: ls -l build/
@@ -50,7 +50,7 @@ jobs:
       - run: yarn lint
       # TODO: Ideally we'd be able to at least run unit tests that don't require docker.
       #- run: yarn test:all
-      - run: yarn global add teraslice-cli@0.62.0
+      - run: yarn global add teraslice-cli
       - run: teraslice-cli -v
       - run: teraslice-cli assets build
       - run: ls -l build/


### PR DESCRIPTION
`teraslice-cli` version was pinned at 0.62.0 because of a bug when converting it to esm. It has been fixed.