### PR TITLE
Update github actions to latest versions

### DIFF
--- a/.github/workflows/asset-build-and-publish.yml
+++ b/.github/workflows/asset-build-and-publish.yml
@@ -19,9 +19,9 @@ jobs:
         # NOTE: Hard Coded Node Version array, should match array in test-asset.yml
         node-version: [18.19.1, 20.11.1, 22.2.0]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: yarn setup
@@ -32,7 +32,7 @@ jobs:
       - run: ls -l ./build/
       - run: sha256sum ./build/*
       - name: Archive production artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: teraslice-asset
           path: ./build
@@ -45,8 +45,8 @@ jobs:
       contents: write
     needs: asset-build
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           # NOTE: Hard Coded Node Version
           node-version: '18.19.1'
@@ -56,12 +56,12 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Download assets from Teraslice Asset Build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: teraslice-asset
           path: ./build/
       - run: ls -l ./build/
       - name: Upload Assets to Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: ./build/*.zip

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -11,15 +11,15 @@ jobs:
         # NOTE: Hard Coded Node Version array, should match array in build-and-publish-asset.yml
         node-version: [18.19.1, 20.11.1, 22.2.0]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       # we login to docker to avoid docker pull limit rates
       # secrets are now duplicated for Actions and Dependabot
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -34,16 +34,16 @@ jobs:
   test-macos:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           # NOTE: Hard Coded Node Version
           node-version: '18.19.1'
       # NOTE: Prevent python 3.12 breaking node-gyp installations in the kafka asset
       # TODO: try default python again in the future 
       - name: Use Python 3.11
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
       - run: yarn setup


### PR DESCRIPTION
This PR makes the following changes:

- Updates `actions/checkout` from `v3` to `v4`
- Updates `actions/setup-node` from `v3` to `v4`
- Updates `actions/upload-artifact` from `v3` to `v4`
- Updates `softprops/action-gh-release` from `v1` to `v2`
- Updates `actions/setup-python` from `v4` to `v5`