### PR TITLE
Unpin node versions in matrix

### DIFF
--- a/.github/workflows/asset-build-and-publish.yml
+++ b/.github/workflows/asset-build-and-publish.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         # NOTE: Hard Coded Node Version array, should match array in test-asset.yml
-        node-version: [18, 20, 22.4.1]
+        node-version: [18, 20, 22]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/asset-build-and-publish.yml
+++ b/.github/workflows/asset-build-and-publish.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         # NOTE: Hard Coded Node Version array, should match array in test-asset.yml
-        node-version: [18.19.1, 20.11.1, 22.2.0]
+        node-version: [18, 20, 22.4.1]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           # NOTE: Hard Coded Node Version
-          node-version: '18.19.1'
+          node-version: '18'
           registry-url: 'https://registry.npmjs.org'
       - run: yarn setup
       - run: ./scripts/publish.sh

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         # NOTE: Hard Coded Node Version array, should match array in build-and-publish-asset.yml
-        node-version: [18, 20, 22.4.1]
+        node-version: [18, 20, 22]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         # NOTE: Hard Coded Node Version array, should match array in build-and-publish-asset.yml
-        node-version: [18.19.1, 20.11.1, 22.2.0]
+        node-version: [18, 20, 22.4.1]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
@@ -39,7 +39,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           # NOTE: Hard Coded Node Version
-          node-version: '18.19.1'
+          node-version: '18'
       # NOTE: Prevent python 3.12 breaking node-gyp installations in the kafka asset
       # TODO: try default python again in the future 
       - name: Use Python 3.11


### PR DESCRIPTION
This PR makes the following changes:

- Updates the node version matrix for asset tests to use the newest major versions of node `18` and `20`

Ref to issue #21