### PR TITLE
Add restore cache step to test-asset workflow

### DIFF
--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           yarn docker:listImages
           cat ./images/image-list.txt
+        continue-on-error: true
       - name: Restore Docker image cache
         id: docker-cache
         uses: actions/cache@v4

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -5,16 +5,9 @@ on:
 
 jobs:
   check-docker-limit-before:
-    runs-on: ubuntu-latest
     if: ${{ github.repository != 'terascope/standard-assets' }}
-    steps:
-    - uses: actions/checkout@v3
-
-    - name: Check docker.hub limit start
-      env:
-        USER: ${{ secrets.DOCKER_USERNAME }}
-        PASS: ${{ secrets.DOCKER_PASSWORD }}
-      run: yarn docker:limit  
+    uses: ./.github/workflows/check-docker-limit.yml
+    secrets: inherit 
 
   cache-docker-images:
     if: ${{ github.repository != 'terascope/standard-assets' }}
@@ -88,14 +81,6 @@ jobs:
       - run: ls -l build/
 
   check-docker-limit-after:
-    runs-on: ubuntu-latest
-    if: ${{ github.repository != 'terascope/standard-assets' }}
     needs: test-linux
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Check docker.hub limit after
-      env:
-        USER: ${{ secrets.DOCKER_USERNAME }}
-        PASS: ${{ secrets.DOCKER_PASSWORD }}
-      run: yarn docker:limit
+    uses: ./.github/workflows/check-docker-limit.yml
+    secrets: inherit 

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -153,3 +153,4 @@ jobs:
         USER: ${{ secrets.DOCKER_USERNAME }}
         PASS: ${{ secrets.DOCKER_PASSWORD }}
       run: yarn docker:limit
+      

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -17,64 +17,10 @@ jobs:
       run: yarn docker:limit  
 
   cache-docker-images:
-    runs-on: ubuntu-latest
     if: ${{ github.repository != 'terascope/standard-assets' }}
     needs: check-docker-limit-before
-    steps:
-    - name: Check out code
-      uses: actions/checkout@v4
-
-    - name: Setup Node
-      uses: actions/setup-node@v4
-      with:
-        node-version: 18
-        cache: 'yarn'
-
-    # we login to docker to avoid docker pull limit rates
-    - name: Login to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-
-    - name: Check docker.hub limit start of job
-      env:
-        USER: ${{ secrets.DOCKER_USERNAME }}
-        PASS: ${{ secrets.DOCKER_PASSWORD }}
-      run: yarn docker:limit
-
-    - name: Install and build packages
-      run: yarn setup
-
-    - name: Create Docker Image List
-      run: |
-        yarn docker:listImages
-        cat ./images/image-list.txt
-
-    - name: Restore Docker image cache
-      id: docker-cache
-      uses: actions/cache@v4
-      with:
-        path: /tmp/docker_cache
-        key: docker-images-${{ hashFiles('./images/image-list.txt') }}
-        lookup-only: true
-
-    - name: Pull and save Docker images
-      if: ${{steps.docker-cache.outputs.cache-hit != 'true'}}
-      run: yarn docker:saveImages
-
-    - name: Update Docker image cache
-      if: ${{steps.docker-cache.outputs.cache-hit != 'true'}}
-      uses: actions/cache/save@v4
-      with:
-        path: /tmp/docker_cache
-        key: docker-images-${{ hashFiles('./images/image-list.txt') }}
-
-    - name: Check docker.hub limit end of job
-      env:
-        USER: ${{ secrets.DOCKER_USERNAME }}
-        PASS: ${{ secrets.DOCKER_PASSWORD }}
-      run: npm run docker:limit
+    uses: ./.github/workflows/cache-docker-images.yml
+    secrets: inherit
 
   test-linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -4,8 +4,81 @@ on:
   workflow_call:
 
 jobs:
+  check-docker-limit-before:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository != 'terascope/standard-assets' }}
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Check docker.hub limit start
+      env:
+        USER: ${{ secrets.DOCKER_USERNAME }}
+        PASS: ${{ secrets.DOCKER_PASSWORD }}
+      run: yarn docker:limit  
+
+  cache-docker-images:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository != 'terascope/standard-assets' }}
+    needs: check-docker-limit-before
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: 18
+        cache: 'yarn'
+
+    # we login to docker to avoid docker pull limit rates
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Check docker.hub limit start of job
+      env:
+        USER: ${{ secrets.DOCKER_USERNAME }}
+        PASS: ${{ secrets.DOCKER_PASSWORD }}
+      run: yarn docker:limit
+
+    - name: Install and build packages
+      run: yarn setup
+
+    - name: Create Docker Image List
+      run: |
+        yarn docker:listImages
+        cat ./images/image-list.txt
+
+    - name: Restore Docker image cache
+      id: docker-cache
+      uses: actions/cache@v4
+      with:
+        path: /tmp/docker_cache
+        key: docker-images-${{ hashFiles('./images/image-list.txt') }}
+        lookup-only: true
+
+    - name: Pull and save Docker images
+      if: ${{steps.docker-cache.outputs.cache-hit != 'true'}}
+      run: yarn docker:saveImages
+
+    - name: Update Docker image cache
+      if: ${{steps.docker-cache.outputs.cache-hit != 'true'}}
+      uses: actions/cache/save@v4
+      with:
+        path: /tmp/docker_cache
+        key: docker-images-${{ hashFiles('./images/image-list.txt') }}
+
+    - name: Check docker.hub limit end of job
+      env:
+        USER: ${{ secrets.DOCKER_USERNAME }}
+        PASS: ${{ secrets.DOCKER_PASSWORD }}
+      run: npm run docker:limit
+
   test-linux:
     runs-on: ubuntu-latest
+    needs: cache-docker-images
     strategy:
       matrix:
         # NOTE: Hard Coded Node Version array, should match array in build-and-publish-asset.yml
@@ -19,6 +92,7 @@ jobs:
       # we login to docker to avoid docker pull limit rates
       # secrets are now duplicated for Actions and Dependabot
       - name: Login to Docker Hub
+        if: ${{ github.repository != 'terascope/standard-assets' }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -26,11 +100,12 @@ jobs:
       - run: yarn setup
       - run: yarn lint
       - name: Create Docker Image List
+        if: ${{ github.repository != 'terascope/standard-assets' }}
         run: |
           yarn docker:listImages
           cat ./images/image-list.txt
-        continue-on-error: true
       - name: Restore Docker image cache
+        if: ${{ github.repository != 'terascope/standard-assets' }}
         id: docker-cache
         uses: actions/cache@v4
         with:
@@ -44,6 +119,7 @@ jobs:
 
   test-macos:
     runs-on: macos-latest
+    if: ${{ github.repository != 'terascope/standard-assets' }}
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js
@@ -65,3 +141,15 @@ jobs:
       - run: teraslice-cli -v
       - run: teraslice-cli assets build
       - run: ls -l build/
+
+  check-docker-limit-after:
+    runs-on: ubuntu-latest
+    needs: test-linux
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Check docker.hub limit after
+      env:
+        USER: ${{ secrets.DOCKER_USERNAME }}
+        PASS: ${{ secrets.DOCKER_PASSWORD }}
+      run: yarn docker:limit

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -119,7 +119,6 @@ jobs:
 
   test-macos:
     runs-on: macos-latest
-    if: ${{ github.repository != 'terascope/standard-assets' }}
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js
@@ -144,6 +143,7 @@ jobs:
 
   check-docker-limit-after:
     runs-on: ubuntu-latest
+    if: ${{ github.repository != 'terascope/standard-assets' }}
     needs: test-linux
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -153,4 +153,3 @@ jobs:
         USER: ${{ secrets.DOCKER_USERNAME }}
         PASS: ${{ secrets.DOCKER_PASSWORD }}
       run: yarn docker:limit
-      

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -5,12 +5,10 @@ on:
 
 jobs:
   check-docker-limit-before:
-    if: ${{ github.repository != 'terascope/standard-assets' }}
     uses: ./.github/workflows/check-docker-limit.yml
     secrets: inherit 
 
   cache-docker-images:
-    if: ${{ github.repository != 'terascope/standard-assets' }}
     needs: check-docker-limit-before
     uses: ./.github/workflows/cache-docker-images.yml
     secrets: inherit
@@ -31,7 +29,6 @@ jobs:
       # we login to docker to avoid docker pull limit rates
       # secrets are now duplicated for Actions and Dependabot
       - name: Login to Docker Hub
-        if: ${{ github.repository != 'terascope/standard-assets' }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -39,12 +36,10 @@ jobs:
       - run: yarn setup
       - run: yarn lint
       - name: Create Docker Image List
-        if: ${{ github.repository != 'terascope/standard-assets' }}
         run: |
           yarn docker:listImages
           cat ./images/image-list.txt
       - name: Restore Docker image cache
-        if: ${{ github.repository != 'terascope/standard-assets' }}
         id: docker-cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -25,6 +25,16 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
       - run: yarn setup
       - run: yarn lint
+      - name: Create Docker Image List
+        run: |
+          yarn docker:listImages
+          cat ./images/image-list.txt
+      - name: Restore Docker image cache
+        id: docker-cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/docker_cache
+          key: docker-images-${{ hashFiles('./images/image-list.txt') }}
       - run: yarn test:all
       - run: yarn global add teraslice-cli
       - run: teraslice-cli -v

--- a/.github/workflows/cache-docker-images.yml
+++ b/.github/workflows/cache-docker-images.yml
@@ -29,9 +29,10 @@ jobs:
         YARN_SETUP_ARGS: "--prod=false --silent"
 
     - name: Create Docker Image List
+      id: image-list
       run: |
         yarn docker:listImages
-        cat ./images/image-list.txt
+        echo "LIST_CONTENTS=$( cat ./images/image-list.txt )" >> $GITHUB_OUTPUT 
 
     - name: Check for Docker image cache
       id: docker-cache
@@ -46,7 +47,7 @@ jobs:
       run: yarn docker:saveImages
 
     - name: Update Docker image cache if no cache hit
-      if: ${{steps.docker-cache.outputs.cache-hit != 'true'}}
+      if: ${{steps.docker-cache.outputs.cache-hit != 'true'}} && ${{steps.image-list.outputs.LIST_CONTENTS != ''}}
       uses: actions/cache/save@v4
       with:
         path: /tmp/docker_cache

--- a/.github/workflows/cache-docker-images.yml
+++ b/.github/workflows/cache-docker-images.yml
@@ -1,0 +1,53 @@
+name: Cache Docker Images
+
+on:
+  workflow_call:
+
+jobs:
+  cache-docker-images:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: 18
+        cache: 'yarn'
+
+    # we login to docker to avoid docker pull limit rates
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Install and build packages
+      run: yarn setup
+      env:
+        YARN_SETUP_ARGS: "--prod=false --silent"
+
+    - name: Create Docker Image List
+      run: |
+        yarn docker:listImages
+        cat ./images/image-list.txt
+
+    - name: Restore Docker image cache
+      id: docker-cache
+      uses: actions/cache@v4
+      with:
+        path: /tmp/docker_cache
+        key: docker-images-${{ hashFiles('./images/image-list.txt') }}
+        lookup-only: true
+
+    - name: Pull and save Docker images
+      if: ${{steps.docker-cache.outputs.cache-hit != 'true'}}
+      run: yarn docker:saveImages
+
+    - name: Update Docker image cache
+      if: ${{steps.docker-cache.outputs.cache-hit != 'true'}}
+      uses: actions/cache/save@v4
+      with:
+        path: /tmp/docker_cache
+        key: docker-images-${{ hashFiles('./images/image-list.txt') }}

--- a/.github/workflows/cache-docker-images.yml
+++ b/.github/workflows/cache-docker-images.yml
@@ -1,4 +1,4 @@
-name: Cache Docker Images
+name: Cache Docker Images If No Cache Found
 
 on:
   workflow_call:
@@ -33,7 +33,7 @@ jobs:
         yarn docker:listImages
         cat ./images/image-list.txt
 
-    - name: Restore Docker image cache
+    - name: Check for Docker image cache
       id: docker-cache
       uses: actions/cache@v4
       with:
@@ -41,11 +41,11 @@ jobs:
         key: docker-images-${{ hashFiles('./images/image-list.txt') }}
         lookup-only: true
 
-    - name: Pull and save Docker images
+    - name: Pull and save Docker images if no cache hit
       if: ${{steps.docker-cache.outputs.cache-hit != 'true'}}
       run: yarn docker:saveImages
 
-    - name: Update Docker image cache
+    - name: Update Docker image cache if no cache hit
       if: ${{steps.docker-cache.outputs.cache-hit != 'true'}}
       uses: actions/cache/save@v4
       with:

--- a/.github/workflows/check-docker-limit.yml
+++ b/.github/workflows/check-docker-limit.yml
@@ -4,12 +4,12 @@ on:
   workflow_call:
 
 jobs:
-  check-docker-limit-before:
+  check-docker-pull-rate-limit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - name: Check docker.hub limit start
+    - name: Check docker.hub pull limit
       env:
         USER: ${{ secrets.DOCKER_USERNAME }}
         PASS: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/check-docker-limit.yml
+++ b/.github/workflows/check-docker-limit.yml
@@ -1,0 +1,16 @@
+name: Check Docker Pull Rate Limit
+
+on:
+  workflow_call:
+
+jobs:
+  check-docker-limit-before:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Check docker.hub limit start
+      env:
+        USER: ${{ secrets.DOCKER_USERNAME }}
+        PASS: ${{ secrets.DOCKER_PASSWORD }}
+      run: yarn docker:limit

--- a/.github/workflows/refresh-docker-cache.yml
+++ b/.github/workflows/refresh-docker-cache.yml
@@ -4,8 +4,13 @@ on:
   workflow_call:
 
 jobs:
-  cache-docker-images:
+  Check-docker-limit-before:
+    uses: ./.github/workflows/check-docker-limit.yml
+    secrets: inherit
+
+  refresh-docker-cache:
     runs-on: ubuntu-latest
+    needs: Check-docker-limit-before
 
     # # final check to make sure it runs only on master branch
     if: github.ref == 'refs/heads/master'
@@ -26,12 +31,6 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-
-    - name: Check docker.hub limit start of job
-      env:
-        USER: ${{ secrets.DOCKER_USERNAME }}
-        PASS: ${{ secrets.DOCKER_PASSWORD }}
-      run: yarn docker:limit
 
     - name: Install and build packages
       run: yarn setup
@@ -81,8 +80,7 @@ jobs:
         path: /tmp/docker_cache
         key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
-    - name: Check docker.hub limit end of job
-      env:
-        USER: ${{ secrets.DOCKER_USERNAME }}
-        PASS: ${{ secrets.DOCKER_PASSWORD }}
-      run: yarn run docker:limit
+  Check-docker-limit-after:
+    needs: refresh-docker-cache
+    uses: ./.github/workflows/check-docker-limit.yml
+    secrets: inherit

--- a/.github/workflows/refresh-docker-cache.yml
+++ b/.github/workflows/refresh-docker-cache.yml
@@ -42,7 +42,7 @@ jobs:
         yarn docker:listImages
         cat ./images/image-list.txt
 
-    - name: Restore Docker image cache
+    - name: Check for Docker image cache
       id: docker-cache
       uses: actions/cache@v4
       with:
@@ -50,7 +50,7 @@ jobs:
         key: docker-images-${{ hashFiles('./images/image-list.txt') }}
         lookup-only: true
 
-    - name: Clear old docker cache
+    - name: Clear old docker cache if present
       if: ${{steps.docker-cache.outputs.cache-hit == 'true'}}
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/refresh-docker-cache.yml
+++ b/.github/workflows/refresh-docker-cache.yml
@@ -85,4 +85,4 @@ jobs:
       env:
         USER: ${{ secrets.DOCKER_USERNAME }}
         PASS: ${{ secrets.DOCKER_PASSWORD }}
-      run: npm run docker:limit
+      run: yarn run docker:limit

--- a/.github/workflows/refresh-docker-cache.yml
+++ b/.github/workflows/refresh-docker-cache.yml
@@ -1,0 +1,88 @@
+name: Refresh Docker Cache
+
+on:
+  workflow_call:
+
+jobs:
+  cache-docker-images:
+    runs-on: ubuntu-latest
+
+    # # final check to make sure it runs only on master branch
+    if: github.ref == 'refs/heads/master'
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: 18
+        cache: 'yarn'
+
+    # we login to docker to avoid docker pull limit rates
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Check docker.hub limit start of job
+      env:
+        USER: ${{ secrets.DOCKER_USERNAME }}
+        PASS: ${{ secrets.DOCKER_PASSWORD }}
+      run: yarn docker:limit
+
+    - name: Install and build packages
+      run: yarn setup
+      env:
+        YARN_SETUP_ARGS: "--prod=false --silent"
+
+    - name: Create Docker Image List
+      run: |
+        yarn docker:listImages
+        cat ./images/image-list.txt
+
+    - name: Restore Docker image cache
+      id: docker-cache
+      uses: actions/cache@v4
+      with:
+        path: /tmp/docker_cache
+        key: docker-images-${{ hashFiles('./images/image-list.txt') }}
+        lookup-only: true
+
+    - name: Clear old docker cache
+      if: ${{steps.docker-cache.outputs.cache-hit == 'true'}}
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        BRANCH: refs/heads/master
+      run: |
+        gh extension install actions/gh-actions-cache
+
+        echo "Fetching list of cache key"
+        cacheKeysForPR=$(gh actions-cache list --key "docker-images-" -R $REPO -B $BRANCH -L 100 | cut -f 1 )
+
+        ## Setting this to not fail the workflow while deleting cache keys.
+        set +e
+        echo "Deleting caches..."
+        for cacheKey in $cacheKeysForPR
+        do
+            gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+        done
+        echo "Done"
+
+    - name: Pull and save Docker images
+      run: yarn docker:saveImages
+
+    - name: Update Docker image cache
+      uses: actions/cache/save@v4
+      with:
+        path: /tmp/docker_cache
+        key: docker-images-${{ hashFiles('./images/image-list.txt') }}
+
+    - name: Check docker.hub limit end of job
+      env:
+        USER: ${{ secrets.DOCKER_USERNAME }}
+        PASS: ${{ secrets.DOCKER_PASSWORD }}
+      run: npm run docker:limit


### PR DESCRIPTION
This PR makes the following changes:
- Creates a `refresh-docker-cache.yml` reusable workflow.
- Creates a `cache-docker-images.yml` reusable workflow.
- Creates a `check-docker-limits.yml` reusable workflow.
- Update `asset-test.yml`:
  - Add `cache-docker-images` and `check-docker-limit` jobs
  - Add `Create Docker Image List` and `Restore Docker image cache` steps to `test-linux` job