### PR TITLE
Don't check for contents in image-list.txt

### DIFF
--- a/.github/workflows/cache-docker-images.yml
+++ b/.github/workflows/cache-docker-images.yml
@@ -32,7 +32,7 @@ jobs:
       id: image-list
       run: |
         yarn docker:listImages
-        echo "LIST_CONTENTS=$( cat ./images/image-list.txt )" >> $GITHUB_OUTPUT 
+        cat ./images/image-list.txt
 
     - name: Check for Docker image cache
       id: docker-cache
@@ -47,7 +47,7 @@ jobs:
       run: yarn docker:saveImages
 
     - name: Update Docker image cache if no cache hit
-      if: ${{steps.docker-cache.outputs.cache-hit != 'true'}} && ${{steps.image-list.outputs.LIST_CONTENTS != ''}}
+      if: ${{steps.docker-cache.outputs.cache-hit != 'true'}}
       uses: actions/cache/save@v4
       with:
         path: /tmp/docker_cache


### PR DESCRIPTION
The previous PR set up `cache-docker-images.yml` to store the contents of a text file into $GITHUB_OUTPUT, but there were two issues:
- A different syntax should have been used to account for multi-line strings. This is a simple fix.
- If the text file was empty the saved variable was not an empty string as expected, so caching still occurred. It will take some digging to see how the empty file is actually saved as a variable.

The second failure forced the creation of a cache, and making an empty cache turns out to be acceptable. It doesn't increase the CI runtime by more than a second or two. This PR removes the check on whether the text file is empty, until I can come up with a solution to the second issue.