### PR TITLE
Fix CI Teraslice-cli Install Issue: Pin "point-in-polygon-hao" to v1.1.0 in Yarn Global

### DIFF
--- a/.github/workflows/asset-build-and-publish.yml
+++ b/.github/workflows/asset-build-and-publish.yml
@@ -26,8 +26,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: yarn setup
       - run: yarn build
-      - name: Ensure jq is installed
-        run: sudo apt-get update && sudo apt-get install -y jq
 
       # This step is a temporary fix for a bug in point-in-polygon-hao
       # We are adding a yarn global resolution to pin it at v1.1.0

--- a/.github/workflows/asset-build-and-publish.yml
+++ b/.github/workflows/asset-build-and-publish.yml
@@ -28,6 +28,9 @@ jobs:
       - run: yarn build
       - name: Ensure jq is installed
         run: sudo apt-get update && sudo apt-get install -y jq
+
+      # This step is a temporary fix for a bug in point-in-polygon-hao
+      # We are adding a yarn global resolution to pin it at v1.1.0
       - name: Locate and Add Resolution to Global Package.json
         run: |
           GLOBAL_PACKAGE_DIR=$(yarn global dir)
@@ -35,9 +38,7 @@ jobs:
           echo "export PATH=$(yarn global bin):\$PATH" >> $GITHUB_ENV
           yarn global add dummy-package
           PACKAGE_JSON="$GLOBAL_PACKAGE_DIR/package.json"
-          echo "Updating $PACKAGE_JSON"
           jq '.resolutions["point-in-polygon-hao"] = "1.1.0"' $PACKAGE_JSON > /tmp/pkg.json && mv /tmp/pkg.json $PACKAGE_JSON
-          cat $PACKAGE_JSON
       - run: yarn global add teraslice-cli
       - run: teraslice-cli -v
       - run: teraslice-cli assets build

--- a/.github/workflows/asset-build-and-publish.yml
+++ b/.github/workflows/asset-build-and-publish.yml
@@ -26,6 +26,15 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: yarn setup
       - run: yarn build
+      - name: Ensure jq is installed
+        run: sudo apt-get update && sudo apt-get install -y jq
+      - name: Locate and Add Resolution to Global Package.json
+        run: |
+          GLOBAL_PACKAGE_DIR=$(yarn global dir)
+          PACKAGE_JSON="$GLOBAL_PACKAGE_DIR/package.json"
+          echo "Updating $PACKAGE_JSON"
+          jq '.resolutions["point-in-polygon-hao"] = "1.1.0"' $PACKAGE_JSON > tmp.json && mv tmp.json $PACKAGE_JSON
+          cat $PACKAGE_JSON
       - run: yarn global add teraslice-cli
       - run: teraslice-cli -v
       - run: teraslice-cli assets build

--- a/.github/workflows/asset-build-and-publish.yml
+++ b/.github/workflows/asset-build-and-publish.yml
@@ -31,9 +31,12 @@ jobs:
       - name: Locate and Add Resolution to Global Package.json
         run: |
           GLOBAL_PACKAGE_DIR=$(yarn global dir)
+          mkdir -p "$GLOBAL_PACKAGE_DIR"
+          echo "export PATH=$(yarn global bin):\$PATH" >> $GITHUB_ENV
+          yarn global add dummy-package
           PACKAGE_JSON="$GLOBAL_PACKAGE_DIR/package.json"
           echo "Updating $PACKAGE_JSON"
-          jq '.resolutions["point-in-polygon-hao"] = "1.1.0"' $PACKAGE_JSON > tmp.json && mv tmp.json $PACKAGE_JSON
+          jq '.resolutions["point-in-polygon-hao"] = "1.1.0"' $PACKAGE_JSON > /tmp/pkg.json && mv /tmp/pkg.json $PACKAGE_JSON
           cat $PACKAGE_JSON
       - run: yarn global add teraslice-cli
       - run: teraslice-cli -v

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -53,7 +53,7 @@ jobs:
           GLOBAL_PACKAGE_DIR=$(yarn global dir)
           mkdir -p "$GLOBAL_PACKAGE_DIR"
           echo "export PATH=$(yarn global bin):\$PATH" >> $GITHUB_ENV
-          run: yarn global add dummy-package
+          yarn global add dummy-package
           PACKAGE_JSON="$GLOBAL_PACKAGE_DIR/package.json"
           echo "Updating $PACKAGE_JSON"
           jq '.resolutions["point-in-polygon-hao"] = "1.1.0"' $PACKAGE_JSON > /tmp/pkg.json && mv /tmp/pkg.json $PACKAGE_JSON
@@ -87,10 +87,12 @@ jobs:
       - name: Locate and Add Resolution to Global Package.json
         run: |
           GLOBAL_PACKAGE_DIR=$(yarn global dir)
+          mkdir -p "$GLOBAL_PACKAGE_DIR"
+          echo "export PATH=$(yarn global bin):\$PATH" >> $GITHUB_ENV
+          yarn global add dummy-package
           PACKAGE_JSON="$GLOBAL_PACKAGE_DIR/package.json"
-          cat $PACKAGE_JSON
           echo "Updating $PACKAGE_JSON"
-          jq '.resolutions["point-in-polygon-hao"] = "1.1.0"' $PACKAGE_JSON > tmp.json && mv tmp.json $PACKAGE_JSON
+          jq '.resolutions["point-in-polygon-hao"] = "1.1.0"' $PACKAGE_JSON > /tmp/pkg.json && mv /tmp/pkg.json $PACKAGE_JSON
           cat $PACKAGE_JSON
       - run: yarn global add teraslice-cli
       - run: teraslice-cli -v

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -46,8 +46,9 @@ jobs:
           path: /tmp/docker_cache
           key: docker-images-${{ hashFiles('./images/image-list.txt') }}
       - run: yarn test:all
-      - name: Ensure jq is installed
-        run: sudo apt-get update && sudo apt-get install -y jq
+      
+      # This step is a temporary fix for a bug in point-in-polygon-hao
+      # We are adding a yarn global resolution to pin it at v1.1.0
       - name: Locate and Add Resolution to Global Package.json
         run: |
           GLOBAL_PACKAGE_DIR=$(yarn global dir)
@@ -55,9 +56,7 @@ jobs:
           echo "export PATH=$(yarn global bin):\$PATH" >> $GITHUB_ENV
           yarn global add dummy-package
           PACKAGE_JSON="$GLOBAL_PACKAGE_DIR/package.json"
-          echo "Updating $PACKAGE_JSON"
           jq '.resolutions["point-in-polygon-hao"] = "1.1.0"' $PACKAGE_JSON > /tmp/pkg.json && mv /tmp/pkg.json $PACKAGE_JSON
-          cat $PACKAGE_JSON
       - run: yarn global add teraslice-cli
       - run: teraslice-cli -v
       - run: teraslice-cli assets build
@@ -82,8 +81,9 @@ jobs:
       - run: yarn lint
       # TODO: Ideally we'd be able to at least run unit tests that don't require docker.
       #- run: yarn test:all
-      - name: Ensure jq is installed
-        run: brew install jq
+
+      # This step is a temporary fix for a bug in point-in-polygon-hao
+      # We are adding a yarn global resolution to pin it at v1.1.0
       - name: Locate and Add Resolution to Global Package.json
         run: |
           GLOBAL_PACKAGE_DIR=$(yarn global dir)
@@ -91,9 +91,7 @@ jobs:
           echo "export PATH=$(yarn global bin):\$PATH" >> $GITHUB_ENV
           yarn global add dummy-package
           PACKAGE_JSON="$GLOBAL_PACKAGE_DIR/package.json"
-          echo "Updating $PACKAGE_JSON"
           jq '.resolutions["point-in-polygon-hao"] = "1.1.0"' $PACKAGE_JSON > /tmp/pkg.json && mv /tmp/pkg.json $PACKAGE_JSON
-          cat $PACKAGE_JSON
       - run: yarn global add teraslice-cli
       - run: teraslice-cli -v
       - run: teraslice-cli assets build

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -52,6 +52,7 @@ jobs:
         run: |
           GLOBAL_PACKAGE_DIR=$(yarn global dir)
           PACKAGE_JSON="$GLOBAL_PACKAGE_DIR/package.json"
+          cat $PACKAGE_JSON
           echo "Updating $PACKAGE_JSON"
           jq '.resolutions["point-in-polygon-hao"] = "1.1.0"' $PACKAGE_JSON > tmp.json && mv tmp.json $PACKAGE_JSON
           cat $PACKAGE_JSON
@@ -85,6 +86,7 @@ jobs:
         run: |
           GLOBAL_PACKAGE_DIR=$(yarn global dir)
           PACKAGE_JSON="$GLOBAL_PACKAGE_DIR/package.json"
+          cat $PACKAGE_JSON
           echo "Updating $PACKAGE_JSON"
           jq '.resolutions["point-in-polygon-hao"] = "1.1.0"' $PACKAGE_JSON > tmp.json && mv tmp.json $PACKAGE_JSON
           cat $PACKAGE_JSON

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -51,10 +51,12 @@ jobs:
       - name: Locate and Add Resolution to Global Package.json
         run: |
           GLOBAL_PACKAGE_DIR=$(yarn global dir)
+          mkdir -p "$GLOBAL_PACKAGE_DIR"
+          echo "export PATH=$(yarn global bin):\$PATH" >> $GITHUB_ENV
+          run: yarn global add dummy-package
           PACKAGE_JSON="$GLOBAL_PACKAGE_DIR/package.json"
-          cat $PACKAGE_JSON
           echo "Updating $PACKAGE_JSON"
-          jq '.resolutions["point-in-polygon-hao"] = "1.1.0"' $PACKAGE_JSON > tmp.json && mv tmp.json $PACKAGE_JSON
+          jq '.resolutions["point-in-polygon-hao"] = "1.1.0"' $PACKAGE_JSON > /tmp/pkg.json && mv /tmp/pkg.json $PACKAGE_JSON
           cat $PACKAGE_JSON
       - run: yarn global add teraslice-cli
       - run: teraslice-cli -v

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -46,6 +46,15 @@ jobs:
           path: /tmp/docker_cache
           key: docker-images-${{ hashFiles('./images/image-list.txt') }}
       - run: yarn test:all
+      - name: Ensure jq is installed
+        run: sudo apt-get update && sudo apt-get install -y jq
+      - name: Locate and Add Resolution to Global Package.json
+        run: |
+          GLOBAL_PACKAGE_DIR=$(yarn global dir)
+          PACKAGE_JSON="$GLOBAL_PACKAGE_DIR/package.json"
+          echo "Updating $PACKAGE_JSON"
+          jq '.resolutions["point-in-polygon-hao"] = "1.1.0"' $PACKAGE_JSON > tmp.json && mv tmp.json $PACKAGE_JSON
+          cat $PACKAGE_JSON
       - run: yarn global add teraslice-cli
       - run: teraslice-cli -v
       - run: teraslice-cli assets build
@@ -70,6 +79,15 @@ jobs:
       - run: yarn lint
       # TODO: Ideally we'd be able to at least run unit tests that don't require docker.
       #- run: yarn test:all
+      - name: Ensure jq is installed
+        run: brew install jq
+      - name: Locate and Add Resolution to Global Package.json
+        run: |
+          GLOBAL_PACKAGE_DIR=$(yarn global dir)
+          PACKAGE_JSON="$GLOBAL_PACKAGE_DIR/package.json"
+          echo "Updating $PACKAGE_JSON"
+          jq '.resolutions["point-in-polygon-hao"] = "1.1.0"' $PACKAGE_JSON > tmp.json && mv tmp.json $PACKAGE_JSON
+          cat $PACKAGE_JSON
       - run: yarn global add teraslice-cli
       - run: teraslice-cli -v
       - run: teraslice-cli assets build


### PR DESCRIPTION
An update to `point-in-polygon-hao` has broken our `teraslice-cli` install during CI. We need to add a `resolution` to the runner that pins `point-in-polygon-hao` to `1.1.0` within yarn global. We update the package.json with `jq`, so a step is added to ensure it is installed.

This should be removed once `point-in-polygon-hao` updates with a proper fix.