### PR TITLE
Add yarn 4 support to all workflows

### DIFF
--- a/.github/workflows/asset-build-and-publish.yml
+++ b/.github/workflows/asset-build-and-publish.yml
@@ -24,6 +24,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Install Yarn 4
+        run: |
+          corepack enable
+          corepack prepare yarn@4.5.3 --activate
       - run: yarn setup
       - run: yarn build
       - run: yarn global add teraslice-cli
@@ -51,6 +55,10 @@ jobs:
           # NOTE: Hard Coded Node Version
           node-version: '18'
           registry-url: 'https://registry.npmjs.org'
+      - name: Install Yarn 4
+        run: |
+          corepack enable
+          corepack prepare yarn@4.5.3 --activate
       - run: yarn setup
       - run: ./scripts/publish.sh
         env:

--- a/.github/workflows/asset-build-and-publish.yml
+++ b/.github/workflows/asset-build-and-publish.yml
@@ -27,13 +27,12 @@ jobs:
       - name: Install Yarn 4
         run: |
           corepack enable
-          corepack prepare yarn@4.5.3 --activate
+          corepack prepare yarn@4.6.0 --activate
           yarn install
-      - run: yarn setup
+      - run: yarn && yarn setup
       - run: yarn build
-      - run: yarn global add teraslice-cli
-      - run: teraslice-cli -v
-      - run: teraslice-cli assets build
+      - run: yarn dlx teraslice-cli -v
+      - run: yarn dlx teraslice-cli assets build
       - run: ls -l ./build/
       - run: sha256sum ./build/*
       - name: Archive production artifacts
@@ -59,9 +58,9 @@ jobs:
       - name: Install Yarn 4
         run: |
           corepack enable
-          corepack prepare yarn@4.5.3 --activate
+          corepack prepare yarn@4.6.0 --activate
           yarn install
-      - run: yarn setup
+      - run: yarn && yarn setup
       - run: ./scripts/publish.sh
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/asset-build-and-publish.yml
+++ b/.github/workflows/asset-build-and-publish.yml
@@ -28,6 +28,7 @@ jobs:
         run: |
           corepack enable
           corepack prepare yarn@4.5.3 --activate
+          yarn install
       - run: yarn setup
       - run: yarn build
       - run: yarn global add teraslice-cli
@@ -59,6 +60,7 @@ jobs:
         run: |
           corepack enable
           corepack prepare yarn@4.5.3 --activate
+          yarn install
       - run: yarn setup
       - run: ./scripts/publish.sh
         env:

--- a/.github/workflows/asset-build-and-publish.yml
+++ b/.github/workflows/asset-build-and-publish.yml
@@ -24,11 +24,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Install Yarn 4
-        run: |
-          corepack enable
-          corepack prepare yarn@4.6.0 --activate
-          yarn install
       - run: yarn && yarn setup
       - run: yarn build
       - run: yarn dlx teraslice-cli -v
@@ -55,11 +50,6 @@ jobs:
           # NOTE: Hard Coded Node Version
           node-version: '18'
           registry-url: 'https://registry.npmjs.org'
-      - name: Install Yarn 4
-        run: |
-          corepack enable
-          corepack prepare yarn@4.6.0 --activate
-          yarn install
       - run: yarn && yarn setup
       - run: ./scripts/publish.sh
         env:

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -26,12 +26,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      # Install yarn 4
-      - name: Install Yarn 4
-        run: |
-          corepack enable
-          corepack prepare yarn@4.6.0 --activate
-          yarn install
       # we login to docker to avoid docker pull limit rates
       # secrets are now duplicated for Actions and Dependabot
       - name: Login to Docker Hub
@@ -65,12 +59,6 @@ jobs:
         with:
           # NOTE: Hard Coded Node Version
           node-version: '18'
-      # Install yarn 4
-      - name: Install Yarn 4
-        run: |
-          corepack enable
-          corepack prepare yarn@4.6.0 --activate
-          yarn install
       # NOTE: Prevent python 3.12 breaking node-gyp installations in the kafka asset
       # TODO: try default python again in the future 
       - name: Use Python 3.11

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -31,6 +31,7 @@ jobs:
         run: |
           corepack enable
           corepack prepare yarn@4.5.3 --activate
+          yarn install
       # we login to docker to avoid docker pull limit rates
       # secrets are now duplicated for Actions and Dependabot
       - name: Login to Docker Hub

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -26,6 +26,11 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+
+      - name: Install Yarn 4
+        run: |
+          corepack enable
+          corepack prepare yarn@4.5.3 --activate
       # we login to docker to avoid docker pull limit rates
       # secrets are now duplicated for Actions and Dependabot
       - name: Login to Docker Hub

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -26,11 +26,11 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-
+      # Install yarn 4
       - name: Install Yarn 4
         run: |
           corepack enable
-          corepack prepare yarn@4.5.3 --activate
+          corepack prepare yarn@4.6.0 --activate
           yarn install
       # we login to docker to avoid docker pull limit rates
       # secrets are now duplicated for Actions and Dependabot
@@ -39,7 +39,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - run: yarn setup
+      - run: yarn && yarn setup
       - run: yarn lint
       - name: Create Docker Image List
         run: |
@@ -52,9 +52,8 @@ jobs:
           path: /tmp/docker_cache
           key: docker-images-${{ hashFiles('./images/image-list.txt') }}
       - run: yarn test:all
-      - run: yarn global add teraslice-cli
-      - run: teraslice-cli -v
-      - run: teraslice-cli assets build
+      - run: yarn dlx teraslice-cli -v
+      - run: yarn dlx teraslice-cli assets build
       - run: ls -l build/
 
   test-macos:
@@ -66,19 +65,24 @@ jobs:
         with:
           # NOTE: Hard Coded Node Version
           node-version: '18'
+      # Install yarn 4
+      - name: Install Yarn 4
+        run: |
+          corepack enable
+          corepack prepare yarn@4.6.0 --activate
+          yarn install
       # NOTE: Prevent python 3.12 breaking node-gyp installations in the kafka asset
       # TODO: try default python again in the future 
       - name: Use Python 3.11
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - run: yarn setup
+      - run: yarn && yarn setup
       - run: yarn lint
       # TODO: Ideally we'd be able to at least run unit tests that don't require docker.
       #- run: yarn test:all
-      - run: yarn global add teraslice-cli
-      - run: teraslice-cli -v
-      - run: teraslice-cli assets build
+      - run: yarn dlx teraslice-cli -v
+      - run: yarn dlx teraslice-cli assets build
       - run: ls -l build/
 
   check-docker-limit-after:

--- a/.github/workflows/cache-docker-images.yml
+++ b/.github/workflows/cache-docker-images.yml
@@ -16,6 +16,12 @@ jobs:
         node-version: 18
         cache: 'yarn'
 
+    - name: Install Yarn 4
+      run: |
+        corepack enable
+        corepack prepare yarn@4.5.3 --activate
+   
+
     # we login to docker to avoid docker pull limit rates
     - name: Login to Docker Hub
       uses: docker/login-action@v3

--- a/.github/workflows/cache-docker-images.yml
+++ b/.github/workflows/cache-docker-images.yml
@@ -32,8 +32,6 @@ jobs:
 
     - name: Install and build packages
       run: yarn setup
-      env:
-        YARN_SETUP_ARGS: "--prod=false --silent"
 
     - name: Create Docker Image List
       id: image-list

--- a/.github/workflows/cache-docker-images.yml
+++ b/.github/workflows/cache-docker-images.yml
@@ -16,13 +16,6 @@ jobs:
         node-version: 18
         # cache: 'yarn'
 
-    - name: Install Yarn 4
-      run: |
-        corepack enable
-        corepack prepare yarn@4.6.0 --activate
-        yarn install
-   
-
     # we login to docker to avoid docker pull limit rates
     - name: Login to Docker Hub
       uses: docker/login-action@v3

--- a/.github/workflows/cache-docker-images.yml
+++ b/.github/workflows/cache-docker-images.yml
@@ -20,6 +20,7 @@ jobs:
       run: |
         corepack enable
         corepack prepare yarn@4.5.3 --activate
+        yarn install
    
 
     # we login to docker to avoid docker pull limit rates

--- a/.github/workflows/cache-docker-images.yml
+++ b/.github/workflows/cache-docker-images.yml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: 18
-        # cache: 'yarn'
+        cache: 'yarn'
 
     # we login to docker to avoid docker pull limit rates
     - name: Login to Docker Hub

--- a/.github/workflows/cache-docker-images.yml
+++ b/.github/workflows/cache-docker-images.yml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: 18
-        cache: 'yarn'
+        # cache: 'yarn'
 
     - name: Install Yarn 4
       run: |

--- a/.github/workflows/cache-docker-images.yml
+++ b/.github/workflows/cache-docker-images.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install Yarn 4
       run: |
         corepack enable
-        corepack prepare yarn@4.5.3 --activate
+        corepack prepare yarn@4.6.0 --activate
         yarn install
    
 
@@ -31,7 +31,7 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
 
     - name: Install and build packages
-      run: yarn setup
+      run: yarn && yarn setup
 
     - name: Create Docker Image List
       id: image-list

--- a/.github/workflows/check-docker-limit.yml
+++ b/.github/workflows/check-docker-limit.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Install Yarn 4
       run: |
         corepack enable
-        corepack prepare yarn@4.5.3 --activate
+        corepack prepare yarn@4.6.0 --activate
         yarn install
 
     - name: Check docker.hub pull limit

--- a/.github/workflows/check-docker-limit.yml
+++ b/.github/workflows/check-docker-limit.yml
@@ -12,4 +12,4 @@ jobs:
       env:
         USER: ${{ secrets.DOCKER_USERNAME }}
         PASS: ${{ secrets.DOCKER_PASSWORD }}
-      run: yarn docker:limit
+      run: yarn && yarn docker:limit

--- a/.github/workflows/check-docker-limit.yml
+++ b/.github/workflows/check-docker-limit.yml
@@ -9,6 +9,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Install Yarn 4
+      run: |
+        corepack enable
+        corepack prepare yarn@4.5.3 --activate
+
     - name: Check docker.hub pull limit
       env:
         USER: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/check-docker-limit.yml
+++ b/.github/workflows/check-docker-limit.yml
@@ -8,13 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-
-    - name: Install Yarn 4
-      run: |
-        corepack enable
-        corepack prepare yarn@4.6.0 --activate
-        yarn install
-
     - name: Check docker.hub pull limit
       env:
         USER: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/check-docker-limit.yml
+++ b/.github/workflows/check-docker-limit.yml
@@ -13,6 +13,7 @@ jobs:
       run: |
         corepack enable
         corepack prepare yarn@4.5.3 --activate
+        yarn install
 
     - name: Check docker.hub pull limit
       env:

--- a/.github/workflows/refresh-docker-cache.yml
+++ b/.github/workflows/refresh-docker-cache.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: 18
-        # cache: 'yarn'
+        cache: 'yarn'
 
     # we login to docker to avoid docker pull limit rates
     - name: Login to Docker Hub

--- a/.github/workflows/refresh-docker-cache.yml
+++ b/.github/workflows/refresh-docker-cache.yml
@@ -29,6 +29,7 @@ jobs:
       run: |
         corepack enable
         corepack prepare yarn@4.5.3 --activate
+        yarn install
 
     # we login to docker to avoid docker pull limit rates
     - name: Login to Docker Hub

--- a/.github/workflows/refresh-docker-cache.yml
+++ b/.github/workflows/refresh-docker-cache.yml
@@ -25,12 +25,6 @@ jobs:
         node-version: 18
         # cache: 'yarn'
 
-    - name: Install Yarn 4
-      run: |
-        corepack enable
-        corepack prepare yarn@4.6.0 --activate
-        yarn install
-
     # we login to docker to avoid docker pull limit rates
     - name: Login to Docker Hub
       uses: docker/login-action@v3

--- a/.github/workflows/refresh-docker-cache.yml
+++ b/.github/workflows/refresh-docker-cache.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: 18
-        cache: 'yarn'
+        # cache: 'yarn'
 
     - name: Install Yarn 4
       run: |

--- a/.github/workflows/refresh-docker-cache.yml
+++ b/.github/workflows/refresh-docker-cache.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Install Yarn 4
       run: |
         corepack enable
-        corepack prepare yarn@4.5.3 --activate
+        corepack prepare yarn@4.6.0 --activate
         yarn install
 
     # we login to docker to avoid docker pull limit rates
@@ -39,7 +39,7 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
 
     - name: Install and build packages
-      run: yarn setup
+      run: yarn && yarn setup
 
     - name: Create Docker Image List
       run: |

--- a/.github/workflows/refresh-docker-cache.yml
+++ b/.github/workflows/refresh-docker-cache.yml
@@ -25,6 +25,11 @@ jobs:
         node-version: 18
         cache: 'yarn'
 
+    - name: Install Yarn 4
+      run: |
+        corepack enable
+        corepack prepare yarn@4.5.3 --activate
+
     # we login to docker to avoid docker pull limit rates
     - name: Login to Docker Hub
       uses: docker/login-action@v3

--- a/.github/workflows/refresh-docker-cache.yml
+++ b/.github/workflows/refresh-docker-cache.yml
@@ -40,8 +40,6 @@ jobs:
 
     - name: Install and build packages
       run: yarn setup
-      env:
-        YARN_SETUP_ARGS: "--prod=false --silent"
 
     - name: Create Docker Image List
       run: |


### PR DESCRIPTION
This PR makes the following changes:

- Removes incompatible yarn arguments to enable support for yarn 4
- Updates asset tests that involve `teraslice-cli` to use Yarn's `dlx` feature because `yarn global` no longer works as of Yarn `2.x`