### PR TITLE
Update asset-build-and-publish workflow to automate releases

### DIFF
--- a/.github/workflows/asset-build-and-publish.yml
+++ b/.github/workflows/asset-build-and-publish.yml
@@ -4,15 +4,52 @@
 #     branches: [ master ]
 #   pull_request:
 #     branches: [ master ]
-# which is meant to test on PRs to master and and push to master.
+# which is meant to test on PRs to master and push to master.
 
-name: Build and Publish Teraslice Asset
-run-name: ${{ github.actor }} is building and publishing the Teraslice Asset
+name: Build, Publish and Release Teraslice Asset
+run-name: ${{ github.actor }} is building, publishing, and releasing the Teraslice Asset
 on:
   workflow_call:
 
 jobs:
+  # Asset build, publish and release will only occur if the current asset version 
+  # is greater than the latest release or pre-release version
+  version-check:
+    runs-on: ubuntu-latest
+    outputs:
+      version_updated: ${{ steps.version_check.outputs.version_updated}}
+      tag: ${{ steps.version_check.outputs.tag}}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Install semver-compare-cli
+        run: yarn && yarn add semver-compare-cli
+      
+      - name: Check for asset version update
+        id: version_check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CURRENT_VERSION=$(jq -r .version package.json)
+          echo "current version:" $CURRENT_VERSION
+
+          RELEASE_VERSION=$(gh release list --exclude-drafts -L 1 --json tagName --jq '.[].tagName')
+          echo "latest (pre)release version:" $RELEASE_VERSION
+          
+          if ./node_modules/.bin/semver-compare $CURRENT_VERSION gt $RELEASE_VERSION; then
+            echo "Asset version updated from $RELEASE_VERSION to $CURRENT_VERSION, creating release"
+            echo "version_updated=true" >> $GITHUB_OUTPUT
+            echo "tag: v$CURRENT_VERSION"
+            echo "tag=v$CURRENT_VERSION" >> $GITHUB_OUTPUT
+          else
+            echo "Asset version not updated, will not release"
+            echo "version_updated=false" >> $GITHUB_OUTPUT
+          fi
+
   asset-build:
+    needs: [version-check]
+    if: needs.version-check.outputs.version_updated == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -20,48 +57,86 @@ jobs:
         node-version: [18, 20, 22]
     steps:
       - uses: actions/checkout@v4
+      
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+
       - run: yarn && yarn setup
       - run: yarn build
       - run: yarn dlx teraslice-cli -v
       - run: yarn dlx teraslice-cli assets build
       - run: ls -l ./build/
       - run: sha256sum ./build/*
+
       - name: Archive production artifacts
         uses: actions/upload-artifact@v4
         with:
           name: teraslice-asset-${{ matrix.node-version }}
           path: ./build
 
-  # Asset Upload and NPM Publish should be done only after builds from all Node
+  # Asset Release and NPM Publish should be done only after builds from all Node
   # versions have completed.
-  asset-upload:
+  asset-publish-and-release:
+    needs: [version-check, asset-build]
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    needs: asset-build
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-node@v4
         with:
           # NOTE: Hard Coded Node Version
           node-version: '18'
           registry-url: 'https://registry.npmjs.org'
+
       - run: yarn && yarn setup
+
       - run: ./scripts/publish.sh
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Download assets from Teraslice Asset Build
         uses: actions/download-artifact@v4
         with:
           path: ./build/
           pattern: teraslice-asset-*
           merge-multiple: true
+
       - run: ls -l ./build/
-      - name: Upload Assets to Release
+
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.RELEASES_APP_ID }}
+          private-key: ${{ secrets.RELEASES_PRIVATE_KEY }}
+
+      - name: Create Release With Assets
         uses: softprops/action-gh-release@v2
         with:
+          token: ${{ steps.generate-token.outputs.token }}
+          prerelease: true
+          tag_name: ${{ needs.version-check.outputs.tag }}
+          name: ${{ needs.version-check.outputs.tag }}
+          generate_release_notes: true
           files: ./build/*.zip
+
+      - name: Announce release in Slack releases channel
+        id: announce-release
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ vars.SLACK_RELEASES_CHANNEL_ID }}
+            text: |
+              ${{ github.repository }} version ${{ needs.version-check.outputs.tag }} has been released.
+              Please review and revise the automated release notes:
+              https://github.com/${{ github.repository }}/releases/tag/${{ needs.version-check.outputs.tag }}
+  
+      - name: Failed Announcement Response
+        if: ${{ steps.announce-release.outputs.ok == 'false' }}
+        run: echo "Slackbot API failure response - ${{ steps.announce-release.outputs.response }}"


### PR DESCRIPTION
This PR makes the following changes:
- **IMPORTANT**: this PR requires updating all assets that use this workflow. The calling workflow should now run this workflow whenever a PR is merged into master, not when a release is published.
- Add a job to compare the asset version to the latest (pre)release. If the version has been updated then proceed to build, publish, and release.
- Create a release instead of just adding the built assets to the manually created release.
- Announce the release to the `releases` slack channel.