### PR TITLE
upload asset artifacts on test

### DIFF
--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -49,10 +49,10 @@ jobs:
       - run: yarn dlx teraslice-cli -v
       - run: yarn dlx teraslice-cli assets build
       - run: ls -l build/
-      - name:  Archive build artifacts
+      - name:  Archive test build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: teraslice-asset-${{ matrix.node-version }}
+          name: teraslice-test-asset-${{ matrix.node-version }}
           path: ./build
           retention-days: 7
 

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -49,7 +49,7 @@ jobs:
       - run: yarn dlx teraslice-cli -v
       - run: yarn dlx teraslice-cli assets build
       - run: ls -l build/
-      - name:  Archive test build artifacts
+      - name: Archive test build artifacts
         uses: actions/upload-artifact@v4
         with:
           name: teraslice-test-asset-${{ matrix.node-version }}

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -49,6 +49,12 @@ jobs:
       - run: yarn dlx teraslice-cli -v
       - run: yarn dlx teraslice-cli assets build
       - run: ls -l build/
+      - name:  Archive build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: teraslice-asset-${{ matrix.node-version }}
+          path: ./build
+          retention-days: 7
 
   test-macos:
     runs-on: macos-latest


### PR DESCRIPTION
This PR adds a step to the `asset-test.yml` workflow that will upload the built asset for each node version to github as an artifact.