### PR TITLE
add dev tag to build artifacts in asset-test workflow

### DIFF
--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -46,13 +46,22 @@ jobs:
           path: /tmp/docker_cache
           key: docker-images-${{ hashFiles('./images/image-list.txt') }}
       - run: yarn test:all
+      - name: Get Commit Short SHA
+        id: get-short-sha
+        run: |
+          calculatedSha=$(git rev-parse --short ${{ github.sha }})
+          echo "COMMIT_SHORT_SHA=$calculatedSha" >> $GITHUB_OUTPUT
+      - name: Append dev tag to version
+        run: |
+          jq '.version += "-dev.${{ steps.get-short-sha.outputs.COMMIT_SHORT_SHA }}"' asset/asset.json > tempAsset.json && mv tempAsset.json asset/asset.json
+          cat asset/asset.json
       - run: yarn dlx teraslice-cli -v
       - run: yarn dlx teraslice-cli assets build
       - run: ls -l build/
       - name: Archive test build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: teraslice-test-asset-${{ matrix.node-version }}
+          name: teraslice-test-asset-${{ matrix.node-version }}-dev.${{ steps.get-short-sha.outputs.COMMIT_SHORT_SHA }}
           path: ./build
           retention-days: 7
 


### PR DESCRIPTION
This PR makes the following changes:
- `.github/workflows/asset-test.yml` now appends the commit short sha to the `asset.json` version as a release candidate style tag. Ex: `version: 4.2.1.-dev.dfe5de3`
- The build artifact names are appended with the same `-dev.shortSha` tag, preventing naming conflicts when a branch is pushed to multiple times. Ex: `teraslice-test-asset-22-dev.dfe5de3` 