### PR TITLE
ensure sha used to tag assets is HEAD

### DIFF
--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -22,8 +22,6 @@ jobs:
         node-version: [18, 20, 22]
     steps:
       - uses: actions/checkout@v4
-        with: 
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
@@ -51,7 +49,7 @@ jobs:
       - name: Get Commit Short SHA
         id: get-short-sha
         run: |
-          calculatedSha=$(git rev-parse --short HEAD)
+          calculatedSha=$(git rev-parse --short ${{ github.event.pull_request.head.sha || github.sha }})
           echo "COMMIT_SHORT_SHA=$calculatedSha" >> $GITHUB_OUTPUT
       - name: Append dev tag to version
         run: |
@@ -96,14 +94,6 @@ jobs:
     needs: [test-linux, test-macos]
     runs-on: ubuntu-latest
     steps:
-      - name: Identify trigger source
-        run: |
-          echo "Event: ${{ github.event_name }}"
-          echo "Branch: ${{ github.ref }}"
-          echo "PR source branch: ${{ github.head_ref }}"
-          echo "PR head sha: ${{ github.event.pull_request.head.sha }}
-          echo "github sha: ${{ github.sha }}
-
       - name: Get Artifacts List
         id: artifacts-list
         env:

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with: 
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
@@ -89,6 +89,40 @@ jobs:
       - run: yarn dlx teraslice-cli -v
       - run: yarn dlx teraslice-cli assets build
       - run: ls -l build/
+
+  comment-artifact-urls:
+    # skip comment on push event (merge to master)
+    # i f: github.event_name != 'push'
+    needs: [test-linux, test-macos]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Identify trigger source
+        run: |
+          echo "Event: ${{ github.event_name }}"
+          echo "Branch: ${{ github.ref }}"
+          echo "PR source branch: ${{ github.head_ref }}"
+
+      - name: Get Artifacts List
+        id: artifacts-list
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ARTIFACTS_JSON=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts)
+          echo $ARTIFACTS_JSON
+          URL_LIST=$(echo "$ARTIFACTS_JSON" | jq -c  '[.artifacts[] | {name: .name, url:.archive_download_url}]')
+          echo $URL_LIST
+          echo "artifact-urls=$URL_LIST" >> "$GITHUB_OUTPUT"
+          
+      - name: Comment on PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          ARTIFACT_URLS='${{ steps.artifacts-list.outputs.artifact-urls }}'
+          LIST=$(echo "$ARTIFACT_URLS" | jq -r '.[] | "\(.name): \(.url)"')
+          COMMENT=$(printf "Asset artifacts:\n%s" "$LIST")
+          gh api repos/${{ github.repository }}/issues/${PR_NUMBER}/comments -f body="$COMMENT"
+
 
   check-docker-limit-after:
     needs: test-linux

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -96,6 +96,14 @@ jobs:
     needs: [test-linux, test-macos]
     runs-on: ubuntu-latest
     steps:
+      - name: Identify trigger source
+        run: |
+          echo "Event: ${{ github.event_name }}"
+          echo "Branch: ${{ github.ref }}"
+          echo "PR source branch: ${{ github.head_ref }}"
+          echo "PR head sha: ${{ github.event.pull_request.head.sha }}
+          echo "github sha: ${{ github.sha }}
+
       - name: Get Artifacts List
         id: artifacts-list
         env:

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -22,6 +22,8 @@ jobs:
         node-version: [18, 20, 22]
     steps:
       - uses: actions/checkout@v4
+        with: 
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
@@ -49,7 +51,7 @@ jobs:
       - name: Get Commit Short SHA
         id: get-short-sha
         run: |
-          calculatedSha=$(git rev-parse --short ${{ github.sha }})
+          calculatedSha=$(git rev-parse --short HEAD)
           echo "COMMIT_SHORT_SHA=$calculatedSha" >> $GITHUB_OUTPUT
       - name: Append dev tag to version
         run: |

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -92,16 +92,10 @@ jobs:
 
   comment-artifact-urls:
     # skip comment on push event (merge to master)
-    # i f: github.event_name != 'push'
+    if: github.event_name != 'push'
     needs: [test-linux, test-macos]
     runs-on: ubuntu-latest
     steps:
-      - name: Identify trigger source
-        run: |
-          echo "Event: ${{ github.event_name }}"
-          echo "Branch: ${{ github.ref }}"
-          echo "PR source branch: ${{ github.head_ref }}"
-
       - name: Get Artifacts List
         id: artifacts-list
         env:

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -101,17 +101,17 @@ jobs:
         run: |
           ARTIFACTS_JSON=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts)
           echo $ARTIFACTS_JSON
-          URL_LIST=$(echo "$ARTIFACTS_JSON" | jq -c  '[.artifacts[] | {name: .name, url:.archive_download_url}]')
-          echo $URL_LIST
-          echo "artifact-urls=$URL_LIST" >> "$GITHUB_OUTPUT"
+          ID_LIST=$(echo "$ARTIFACTS_JSON" | jq -c  '[.artifacts[] | {name: .name, id:.id}]')
+          echo $ID_LIST
+          echo "artifact-ids=$ID_LIST" >> "$GITHUB_OUTPUT"
           
       - name: Comment on PR
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          ARTIFACT_URLS='${{ steps.artifacts-list.outputs.artifact-urls }}'
-          LIST=$(echo "$ARTIFACT_URLS" | jq -r '.[] | "\(.name): \(.url)"')
+          ARTIFACT_IDS='${{ steps.artifacts-list.outputs.artifact-ids }}'
+          LIST=$(echo "$ARTIFACT_IDS" | jq -r '.[] | "\(.name): https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/\(.id)"')
           COMMENT=$(printf "Asset artifacts:\n%s" "$LIST")
           gh api repos/${{ github.repository }}/issues/${PR_NUMBER}/comments -f body="$COMMENT"
 


### PR DESCRIPTION
This PR makes the following changes:
- `git rev-parse --short` now uses `github.event.pull_request.head.sha` instead of the merge commit on a pull request. 
- Add comment to PR with links to artifacts if all tests pass