### PR TITLE
skip artifact comment on dependabot PRs

### DIFF
--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -89,8 +89,8 @@ jobs:
       - run: ls -l build/
 
   comment-artifact-urls:
-    # skip comment on push event (merge to master)
-    if: github.event_name != 'push'
+    # skip comment on push event (merge to master) and dependabot PRs
+    if: github.event_name != 'push' && github.actor != 'dependabot[bot]'
     needs: [test-linux, test-macos]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The dependabot actor does not have sufficient permissions to make a PR comment. Granting those permissions would allow the dependabot actor to merge PRs, so we will skip making the comment instead.