### PR TITLE
Add test-website and all-tests-passed jobs to asset-test.yml

### DIFF
--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -139,4 +139,4 @@ jobs:
     needs: [test-linux, test-macos, test-website]
     runs-on: ubuntu-latest
     steps:
-      - run: echo "all tests have passed"
+      - run: echo "All tests have passed"

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -97,8 +97,7 @@ jobs:
         with:
           # NOTE: Hard Coded Node Version
           node-version: '22'
-      - run: yarn && yarn setup
-      - run: ./scripts/build-documentation.sh
+      - run: yarn && ./scripts/build-documentation.sh
 
   comment-artifact-urls:
     # skip comment on push event (merge to master) and dependabot PRs

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -88,6 +88,18 @@ jobs:
       - run: yarn dlx teraslice-cli assets build
       - run: ls -l build/
 
+  test-website:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          # NOTE: Hard Coded Node Version
+          node-version: '22'
+      - run: yarn && yarn setup
+      - run: ./scripts/build-documentation.sh
+
   comment-artifact-urls:
     # skip comment on push event (merge to master) and dependabot PRs
     if: github.event_name != 'push' && github.actor != 'dependabot[bot]'

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -134,3 +134,9 @@ jobs:
     needs: test-linux
     uses: ./.github/workflows/check-docker-limit.yml
     secrets: inherit 
+
+  all-tests-passed:
+    needs: [test-linux, test-macos, test-website]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "all tests have passed"

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -97,7 +97,10 @@ jobs:
         with:
           # NOTE: Hard Coded Node Version
           node-version: '22'
-      - run: yarn && ./scripts/build-documentation.sh
+      - name: Build documentation
+        run: yarn && ./scripts/build-documentation.sh
+      - name: Check Output
+        run: find ./website/build
 
   comment-artifact-urls:
     # skip comment on push event (merge to master) and dependabot PRs


### PR DESCRIPTION
This PR adds two new jobs to the `asset-test.yml` workflow:
- test-website
  - use the build-documentation.sh script to build API docs and the docusaurus website
  - check to ensure the build directory is created
- all-tests-passed
  - will only run if all other test jobs succeed
  - will replace `check-docker-limit-after` job as a required job before a PR can be merged
refs: #36, https://github.com/terascope/teraslice/issues/4014 
