### PR TITLE
Fix docker caching logic - remove lookup-only from cache check

### DIFF
--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -44,7 +44,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/docker_cache
-          key: docker-images-${{ hashFiles('./images/image-list.txt') }}
+          key: docker-images-${{ hashFiles('./images/image-list.txt') }}-master
+          restore-keys: |
+            docker-images-${{ hashFiles('./images/image-list.txt') }}-
+            docker-images-
       - run: yarn test:all
       - name: Get Commit Short SHA
         id: get-short-sha
@@ -89,7 +92,7 @@ jobs:
       - run: ls -l build/
 
   test-website:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js

--- a/.github/workflows/cache-docker-images.yml
+++ b/.github/workflows/cache-docker-images.yml
@@ -37,16 +37,17 @@ jobs:
       uses: actions/cache@v4
       with:
         path: /tmp/docker_cache
-        key: docker-images-${{ hashFiles('./images/image-list.txt') }}
-        lookup-only: true
+        key: docker-images-${{ hashFiles('./images/image-list.txt') }}-master
+        restore-keys: |
+          docker-images-${{ hashFiles('./images/image-list.txt') }}-
 
     - name: Pull and save Docker images if no cache hit
-      if: ${{steps.docker-cache.outputs.cache-hit != 'true'}}
+      if: ${{steps.docker-cache.outputs.cache-hit == ''}} 
       run: yarn docker:saveImages
 
     - name: Update Docker image cache if no cache hit
-      if: ${{steps.docker-cache.outputs.cache-hit != 'true'}}
+      if: ${{steps.docker-cache.outputs.cache-hit == ''}}
       uses: actions/cache/save@v4
       with:
         path: /tmp/docker_cache
-        key: docker-images-${{ hashFiles('./images/image-list.txt') }}
+        key: docker-images-${{ hashFiles('./images/image-list.txt') }}-${{github.ref_name}}

--- a/.github/workflows/refresh-docker-cache.yml
+++ b/.github/workflows/refresh-docker-cache.yml
@@ -45,7 +45,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: /tmp/docker_cache
-        key: docker-images-${{ hashFiles('./images/image-list.txt') }}
+        key: docker-images-${{ hashFiles('./images/image-list.txt') }}-master
         lookup-only: true
 
     - name: Clear old docker cache if present
@@ -76,7 +76,7 @@ jobs:
       uses: actions/cache/save@v4
       with:
         path: /tmp/docker_cache
-        key: docker-images-${{ hashFiles('./images/image-list.txt') }}
+        key: docker-images-${{ hashFiles('./images/image-list.txt') }}-master
 
   Check-docker-limit-after:
     needs: refresh-docker-cache


### PR DESCRIPTION
This PR makes the following changes:
- updates the docker cache keys in all relevant workflows to include branch names.
- updates `cache-docker-images`
  -  remove the `lookup-only: true` flag. This only checks if the key exists in some metadata list, not whether the underlying cache still exists and can be retrieved successfully. The cache will be pulled and ensured to work, if not a new branch-specific cache will be created.
  - add `restore-keys` field to match a partial key. This allows the workflow to use a branch-specific cache if the master cache is corrupt or missing.
  - build a new cache if `cache-hit` returns an empty string - the value returned if the primary and backup caches are not found or restoring the cache fails.
- updates `asset-test` to restore from a branch cache if it exists

Background:
We were getting cache hits, but the actual downloads were failing (possibly a corrupted cache file?). 
https://github.com/terascope/teraslice/actions/runs/15743773244/job/44375397314

cache-docker-images job:
```
Run actions/cache@v4
Cache hit for: docker-images-6f3e4d1ceec4b00f0b9ed8f30e5c4668add37db4cf300ed667460f3feaa61155
Lookup only - skipping download
Cache found and can be restored from key: docker-images-6f3e4d1ceec4b00f0b9ed8f30e5c4668add37db4cf300ed667460f3feaa61155
```

downstream jobs:
```
Run actions/cache@v4
Cache hit for: docker-images-6f3e4d1ceec4b00f0b9ed8f30e5c4668add37db4cf300ed667460f3feaa61155
Warning: Failed to restore: 
Cache not found for input keys: docker-images-6f3e4d1ceec4b00f0b9ed8f30e5c4668add37db4cf300ed667460f3feaa61155
```

I then deleted the cache and still got a cache hit, meaning the list of cache keys is not updated immediately after cache deletion.

With `lookup-only:false` the `cache-docker-images` job will get a cache miss when the download fails, triggering a branch specific cache build. That cache will be used in all downstream jobs if it exists.