### PR TITLE
Make test-website job run, but skip all steps if there is no website.

### DIFF
--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -122,8 +122,7 @@ jobs:
       - name: Build documentation and Check Output
         if: needs.check-for-website.outputs.website_exists == 'true'
         run: |
-          yarn && \\
-          ./scripts/build-documentation.sh && \\
+          yarn && ./scripts/build-documentation.sh && \\
           find ./website/build
 
   comment-artifact-urls:

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -122,7 +122,8 @@ jobs:
       - name: Build documentation and Check Output
         if: needs.check-for-website.outputs.website_exists == 'true'
         run: |
-          yarn && ./scripts/build-documentation.sh && \\
+          yarn 
+          ./scripts/build-documentation.sh
           find ./website/build
 
   comment-artifact-urls:

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -112,7 +112,6 @@ jobs:
   test-website:
     runs-on: ubuntu-latest
     needs: check-for-website
-    if: needs.check-for-website.outputs.website_exists == 'true'
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js
@@ -120,10 +119,12 @@ jobs:
         with:
           # NOTE: Hard Coded Node Version
           node-version: '22'
-      - name: Build documentation
-        run: yarn && ./scripts/build-documentation.sh
-      - name: Check Output
-        run: find ./website/build
+      - name: Build documentation and Check Output
+        if: needs.check-for-website.outputs.website_exists == 'true'
+        run: |
+          yarn && \\
+          ./scripts/build-documentation.sh && \\
+          find ./website/build
 
   comment-artifact-urls:
     # skip comment on push event (merge to master) and dependabot PRs


### PR DESCRIPTION
This PR changes the `test-website` job of the asset-test.yml workflow to run the job no matter what, but skip the website build step if there is no website directory. This allows the `all-tests-passed` job to pass if the website doesn't exist for an asset. 