### PR TITLE
Support prerelease branch workflows

### DIFF
--- a/.github/workflows/asset-build-and-publish.yml
+++ b/.github/workflows/asset-build-and-publish.yml
@@ -22,9 +22,6 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-
-      - name: Install semver-compare-cli
-        run: yarn && yarn add semver-compare-cli
       
       - name: Check for asset version update
         id: version_check
@@ -34,11 +31,14 @@ jobs:
           CURRENT_VERSION=$(jq -r .version package.json)
           echo "current version:" $CURRENT_VERSION
 
-          RELEASE_VERSION=$(gh release list --exclude-drafts -L 1 --json tagName --jq '.[].tagName')
-          echo "latest (pre)release version:" $RELEASE_VERSION
+          LATEST_RELEASE_VERSION=$(gh release list --exclude-drafts -L 1 --json tagName --jq '.[].tagName')
+          echo "latest (pre)release version:" $LATEST_RELEASE_VERSION
           
-          if ./node_modules/.bin/semver-compare $CURRENT_VERSION gt $RELEASE_VERSION; then
-            echo "Asset version updated from $RELEASE_VERSION to $CURRENT_VERSION, creating release"
+          COMP_OUTPUT=$(./scripts/semver-tool.sh compare $CURRENT_VERSION $LATEST_RELEASE_VERSION)
+          echo "Semver comparison output:" $COMP_OUTPUT
+
+          if [[ "$COMP_OUTPUT" = "1" ]]; then
+            echo "Asset version updated from $LATEST_RELEASE_VERSION to $CURRENT_VERSION, creating release"
             echo "version_updated=true" >> $GITHUB_OUTPUT
             echo "tag: v$CURRENT_VERSION"
             echo "tag=v$CURRENT_VERSION" >> $GITHUB_OUTPUT

--- a/.github/workflows/prerelease-asset-build-and-publish.yml
+++ b/.github/workflows/prerelease-asset-build-and-publish.yml
@@ -1,7 +1,8 @@
 # NOTE: There are no tests in this publish workflow, which means it assumes that
 # the prerelease branch has been tested.  The test-asset.yml should include:
 #   push:
-#     branches: [ master ]
+#     branches: 
+#       - 'release/*-assets-v*'
 #   pull_request:
 #     branches:
 #       - 'release/*-assets-v*'
@@ -14,7 +15,7 @@ on:
 
 jobs:
   # Asset build, publish and release will only occur if the current asset version 
-  # is greater than the latest release or pre-release version
+  # is a prerelease and is greater than the latest release or pre-release version
   version-check:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/prerelease-asset-build-and-publish.yml
+++ b/.github/workflows/prerelease-asset-build-and-publish.yml
@@ -1,0 +1,150 @@
+# NOTE: There are no tests in this publish workflow, which means it assumes that
+# the prerelease branch has been tested.  The test-asset.yml should include:
+#   push:
+#     branches: [ master ]
+#   pull_request:
+#     branches:
+#       - 'release/*-assets-v*'
+# which is meant to test on PRs to a release branch and push to a release branch.
+
+name: Build, Publish and Release Teraslice Prerelease Asset
+run-name: ${{ github.actor }} is building, publishing, and releasing the Teraslice Prerelease Asset
+on:
+  workflow_call:
+
+jobs:
+  # Asset build, publish and release will only occur if the current asset version 
+  # is greater than the latest release or pre-release version
+  version-check:
+    runs-on: ubuntu-latest
+    outputs:
+      version_updated: ${{ steps.version_check.outputs.version_updated}}
+      tag: ${{ steps.version_check.outputs.tag}}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Install semver-compare-cli
+        run: yarn && yarn add semver-compare-cli
+      
+      - name: Check for asset version update
+        id: version_check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CURRENT_VERSION=$(jq -r .version package.json)
+          echo "current version:" $CURRENT_VERSION
+
+          LATEST_RELEASE_VERSION=$(gh release list --exclude-drafts -L 1 --json tagName --jq '.[].tagName')
+          echo "latest (pre)release version:" $LATEST_RELEASE_VERSION
+
+          COMP_OUTPUT=$(./scripts/semver-tool.sh compare $CURRENT_VERSION $LATEST_RELEASE_VERSION)
+          echo "Semver comparison output:" $COMP_OUTPUT
+
+          PRERELEASE_TAG=$(./scripts/semver-tool.sh get prerelease $CURRENT_VERSION)
+          IS_PRE_RELEASE=$([ -n "$PRERELEASE_TAG" ] && echo true || echo false)
+          echo "is_pre_release=$IS_PRE_RELEASE"
+          
+          if [[ "$COMP_OUTPUT" = "1" && "$IS_PRE_RELEASE" = "true" ]]; then
+            echo "Asset version updated from $LATEST_RELEASE_VERSION to $CURRENT_VERSION, creating release"
+            echo "version_updated=true" >> $GITHUB_OUTPUT
+            echo "tag: v$CURRENT_VERSION"
+            echo "tag=v$CURRENT_VERSION" >> $GITHUB_OUTPUT
+          else
+            echo "Asset pre-release version not updated, will not release"
+            echo "version_updated=false" >> $GITHUB_OUTPUT
+          fi
+
+  asset-build:
+    needs: [version-check]
+    if: needs.version-check.outputs.version_updated == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # NOTE: Hard Coded Node Version array, should match array in test-asset.yml
+        node-version: [22, 24]
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - run: yarn && yarn setup
+      - run: yarn build
+      - run: yarn dlx teraslice-cli -v
+      - run: yarn dlx teraslice-cli assets build
+      - run: ls -l ./build/
+      - run: sha256sum ./build/*
+
+      - name: Archive production artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: teraslice-asset-${{ matrix.node-version }}
+          path: ./build
+
+  # Asset Release and NPM Publish should be done only after builds from all Node
+  # versions have completed.
+  asset-publish-and-release:
+    needs: [version-check, asset-build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          # NOTE: Hard Coded Node Version
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: yarn && yarn setup
+
+      - run: ./scripts/publish.sh --tag prerelease
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Download assets from Teraslice Asset Build
+        uses: actions/download-artifact@v4
+        with:
+          path: ./build/
+          pattern: teraslice-asset-*
+          merge-multiple: true
+
+      - run: ls -l ./build/
+
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.RELEASES_APP_ID }}
+          private-key: ${{ secrets.RELEASES_PRIVATE_KEY }}
+
+      - name: Create Release With Assets
+        uses: softprops/action-gh-release@v2
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          prerelease: true
+          tag_name: ${{ needs.version-check.outputs.tag }}
+          name: ${{ needs.version-check.outputs.tag }}
+          generate_release_notes: true
+          files: ./build/*.zip
+
+      - name: Announce release in Slack releases channel
+        id: announce-release
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ vars.SLACK_RELEASES_CHANNEL_ID }}
+            text: |
+              ${{ github.repository }} prerelease version ${{ needs.version-check.outputs.tag }} has been published.
+              Please review and revise the automated release notes:
+              https://github.com/${{ github.repository }}/releases/tag/${{ needs.version-check.outputs.tag }}
+  
+      - name: Failed Announcement Response
+        if: ${{ steps.announce-release.outputs.ok == 'false' }}
+        run: echo "Slackbot API failure response - ${{ steps.announce-release.outputs.response }}"


### PR DESCRIPTION
This PR makes the following changes:
- add prerelease-asset-build-and-publish.yml workflow that will publish a prerelease on merges to `release/*-assets-v*` branches.
- remove semver-compare-cli usage from asset-build-and-publish.yml and use the semver-tool.sh script that will need to be in each asset.

ref: #46 