### PR TITLE
add target_commitish to prerelease workflow action-gh-release action

### DIFF
--- a/.github/workflows/prerelease-asset-build-and-publish.yml
+++ b/.github/workflows/prerelease-asset-build-and-publish.yml
@@ -24,9 +24,6 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-
-      - name: Install semver-compare-cli
-        run: yarn && yarn add semver-compare-cli
       
       - name: Check for asset version update
         id: version_check
@@ -128,6 +125,7 @@ jobs:
         with:
           token: ${{ steps.generate-token.outputs.token }}
           prerelease: true
+          target_commitish: ${{ github.event.pull_request.base.ref }}
           tag_name: ${{ needs.version-check.outputs.tag }}
           name: ${{ needs.version-check.outputs.tag }}
           generate_release_notes: true


### PR DESCRIPTION
This PR makes the following changes:
- Prerelease workflows need to reference the `release/*-assets-v*` commit as the base branch or the git tag is created on master/main branch by default.
- Remove unnneeded semver-compare-cli install