### PR TITLE
create prerelease-asset-test workflow that uses prerelease teraslice-cli

### DIFF
--- a/.github/workflows/prerelease-asset-test.yml
+++ b/.github/workflows/prerelease-asset-test.yml
@@ -1,0 +1,166 @@
+name: Test Teraslice Asset
+run-name: ${{ github.actor }} is testing the Teraslice Prerelease Asset
+on:
+  workflow_call:
+
+jobs:
+  check-docker-limit-before:
+    uses: ./.github/workflows/check-docker-limit.yml
+    secrets: inherit 
+
+  cache-docker-images:
+    needs: check-docker-limit-before
+    uses: ./.github/workflows/cache-docker-images.yml
+    secrets: inherit
+
+  test-linux:
+    runs-on: ubuntu-latest
+    needs: cache-docker-images
+    strategy:
+      matrix:
+        # NOTE: Hard Coded Node Version array, should match array in build-and-publish-asset.yml
+        node-version: [22, 24]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      # we login to docker to avoid docker pull limit rates
+      # secrets are now duplicated for Actions and Dependabot
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - run: yarn && yarn setup
+      - run: yarn lint
+      - name: Create Docker Image List
+        run: |
+          yarn docker:listImages
+          cat ./images/image-list.txt
+      - name: Restore Docker image cache
+        id: docker-cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/docker_cache
+          key: docker-images-${{ hashFiles('./images/image-list.txt') }}-master
+          restore-keys: |
+            docker-images-${{ hashFiles('./images/image-list.txt') }}-
+            docker-images-
+      - run: yarn test:all
+      - name: Get Commit Short SHA
+        id: get-short-sha
+        run: |
+          calculatedSha=$(git rev-parse --short ${{ github.event.pull_request.head.sha || github.sha }})
+          echo "COMMIT_SHORT_SHA=$calculatedSha" >> $GITHUB_OUTPUT
+      - name: Append dev tag to version
+        run: |
+          jq '.version += "-dev.${{ steps.get-short-sha.outputs.COMMIT_SHORT_SHA }}"' asset/asset.json > tempAsset.json && mv tempAsset.json asset/asset.json
+          cat asset/asset.json
+      - run: yarn dlx teraslice-cli@prerelease -v
+      - run: yarn dlx teraslice-cli@prerelease assets build
+      - run: ls -l build/
+      - name: Archive test build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: teraslice-test-asset-${{ matrix.node-version }}-dev.${{ steps.get-short-sha.outputs.COMMIT_SHORT_SHA }}
+          path: ./build
+          retention-days: 7
+
+  test-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          # NOTE: Hard Coded Node Version
+          node-version: '22'
+      # NOTE: Prevent python 3.12 breaking node-gyp installations in the kafka asset
+      # TODO: try default python again in the future 
+      - name: Use Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: yarn && yarn setup
+      - run: yarn lint
+      # TODO: Ideally we'd be able to at least run unit tests that don't require docker.
+      #- run: yarn test:all
+      - run: yarn dlx teraslice-cli@prerelease -v
+      - run: yarn dlx teraslice-cli@prerelease assets build
+      - run: ls -l build/
+
+  check-for-website:
+    runs-on: ubuntu-latest
+    outputs:
+      website_exists: ${{ steps.find-directory.outputs.website_exists }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Find website directory
+        id: find-directory
+        run: |
+          if [ -d "./website" ]; then
+            echo "Website exists. Website build will be tested."  
+            echo "website_exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "Website does not exist. Website build will not be tested."  
+            echo "website_exists=false" >> $GITHUB_OUTPUT
+          fi
+
+  test-website:
+    runs-on: ubuntu-latest
+    needs: check-for-website
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          # NOTE: Hard Coded Node Version
+          node-version: '22'
+      - name: Build documentation and Check Output
+        if: needs.check-for-website.outputs.website_exists == 'true'
+        run: |
+          yarn 
+          ./scripts/build-documentation.sh
+          find ./website/build
+
+  comment-artifact-urls:
+    # skip comment on push event (merge to master) and dependabot PRs
+    if: github.event_name != 'push' && github.actor != 'dependabot[bot]'
+    needs: [test-linux, test-macos]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get Artifacts List
+        id: artifacts-list
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ARTIFACTS_JSON=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts)
+          echo $ARTIFACTS_JSON
+          ID_LIST=$(echo "$ARTIFACTS_JSON" | jq -c  '[.artifacts[] | {name: .name, id:.id}]')
+          echo $ID_LIST
+          echo "artifact-ids=$ID_LIST" >> "$GITHUB_OUTPUT"
+          
+      - name: Comment on PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          ARTIFACT_IDS='${{ steps.artifacts-list.outputs.artifact-ids }}'
+          LIST=$(echo "$ARTIFACT_IDS" | jq -r '.[] | "\(.name): https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/\(.id)"')
+          COMMENT=$(printf "Asset artifacts:\n%s" "$LIST")
+          gh api repos/${{ github.repository }}/issues/${PR_NUMBER}/comments -f body="$COMMENT"
+
+
+  check-docker-limit-after:
+    needs: test-linux
+    uses: ./.github/workflows/check-docker-limit.yml
+    secrets: inherit 
+
+  all-tests-passed:
+    needs: [test-linux, test-macos, test-website]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "All tests have passed"


### PR DESCRIPTION
Create an asset test workflow for prerelease assets that uses teraslice-cli@prerelease.
See explanation in #49.
This is identical to the main assets-test workflow otherwise.