### PR TITLE
Use NPM trusted publishing

### DIFF
--- a/.github/workflows/asset-build-and-publish.yml
+++ b/.github/workflows/asset-build-and-publish.yml
@@ -16,6 +16,8 @@ jobs:
   # is greater than the latest release or pre-release version
   version-check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       version_updated: ${{ steps.version_check.outputs.version_updated}}
       tag: ${{ steps.version_check.outputs.tag}}
@@ -51,6 +53,8 @@ jobs:
     needs: [version-check]
     if: needs.version-check.outputs.version_updated == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         # NOTE: Hard Coded Node Version array, should match array in test-asset.yml
@@ -147,6 +151,8 @@ jobs:
   check-for-website:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true
+    permissions:
+      contents: read
     outputs:
       website_exists: ${{ steps.find-directory.outputs.website_exists }}
     steps:
@@ -167,6 +173,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [version-check, check-for-website]
     if: needs.version-check.outputs.version_updated == 'true' && needs.check-for-website.outputs.website_exists == 'true'
+    permissions:
+      contents: read
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/asset-build-and-publish.yml
+++ b/.github/workflows/asset-build-and-publish.yml
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-      contents: read
+      contents: write
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/asset-build-and-publish.yml
+++ b/.github/workflows/asset-build-and-publish.yml
@@ -84,7 +84,8 @@ jobs:
     needs: [version-check, asset-build]
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -104,8 +105,6 @@ jobs:
         run: pnpm whoami
 
       - run: ./scripts/publish.sh
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Download assets from Teraslice Asset Build
         uses: actions/download-artifact@v4

--- a/.github/workflows/asset-build-and-publish.yml
+++ b/.github/workflows/asset-build-and-publish.yml
@@ -103,7 +103,7 @@ jobs:
 
       - run: pnpm install && pnpm run setup
 
-      - run: ./scripts/publish.sh
+      - run: pnpm publish -r --no-git-checks
 
       - name: Download assets from Teraslice Asset Build
         uses: actions/download-artifact@v4

--- a/.github/workflows/asset-build-and-publish.yml
+++ b/.github/workflows/asset-build-and-publish.yml
@@ -99,11 +99,6 @@ jobs:
 
       - run: pnpm install && pnpm run setup
 
-      - name: Verify pnpm authentication
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: pnpm whoami
-
       - run: ./scripts/publish.sh
 
       - name: Download assets from Teraslice Asset Build

--- a/.github/workflows/asset-build-and-publish.yml
+++ b/.github/workflows/asset-build-and-publish.yml
@@ -92,7 +92,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           # NOTE: Hard Coded Node Version
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
       - name: Install pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           # NOTE: Hard Coded Node Version
-          node-version: '22'
+          node-version: '24'
       # NOTE: Prevent python 3.12 breaking node-gyp installations in the kafka asset
       # TODO: try default python again in the future 
       - name: Use Python 3.11

--- a/.github/workflows/cache-asset-bundles.yml
+++ b/.github/workflows/cache-asset-bundles.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
-        node-version: 22
+        node-version: 24
         cache: 'pnpm'
 
     - name: Install and build packages

--- a/.github/workflows/cache-docker-images.yml
+++ b/.github/workflows/cache-docker-images.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
-        node-version: 22
+        node-version: 24
         cache: 'pnpm'
 
     # we login to docker to avoid docker pull limit rates

--- a/.github/workflows/prerelease-asset-build-and-publish.yml
+++ b/.github/workflows/prerelease-asset-build-and-publish.yml
@@ -109,7 +109,7 @@ jobs:
 
       - run: pnpm install && pnpm run setup
 
-      - run: ./scripts/publish.sh --tag prerelease
+      - run: pnpm publish -r --tag prerelease --no-git-checks
 
       - name: Download assets from Teraslice Asset Build
         uses: actions/download-artifact@v4

--- a/.github/workflows/prerelease-asset-build-and-publish.yml
+++ b/.github/workflows/prerelease-asset-build-and-publish.yml
@@ -98,7 +98,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           # NOTE: Hard Coded Node Version
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
       - name: Install pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/prerelease-asset-build-and-publish.yml
+++ b/.github/workflows/prerelease-asset-build-and-publish.yml
@@ -91,7 +91,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-      contents: read
+      contents: write
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/prerelease-asset-build-and-publish.yml
+++ b/.github/workflows/prerelease-asset-build-and-publish.yml
@@ -90,7 +90,8 @@ jobs:
     needs: [version-check, asset-build]
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -105,8 +106,6 @@ jobs:
       - run: pnpm install && pnpm run setup
 
       - run: ./scripts/publish.sh --tag prerelease
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Download assets from Teraslice Asset Build
         uses: actions/download-artifact@v4

--- a/.github/workflows/prerelease-asset-build-and-publish.yml
+++ b/.github/workflows/prerelease-asset-build-and-publish.yml
@@ -18,6 +18,8 @@ jobs:
   # is a prerelease and is greater than the latest release or pre-release version
   version-check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       version_updated: ${{ steps.version_check.outputs.version_updated}}
       tag: ${{ steps.version_check.outputs.tag}}
@@ -57,6 +59,8 @@ jobs:
     needs: [version-check]
     if: needs.version-check.outputs.version_updated == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         # NOTE: Hard Coded Node Version array, should match array in test-asset.yml

--- a/.github/workflows/prerelease-asset-test.yml
+++ b/.github/workflows/prerelease-asset-test.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           # NOTE: Hard Coded Node Version
-          node-version: '22'
+          node-version: '24'
       # NOTE: Prevent python 3.12 breaking node-gyp installations in the kafka asset
       # TODO: try default python again in the future 
       - name: Use Python 3.11
@@ -122,7 +122,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           # NOTE: Hard Coded Node Version
-          node-version: '22'
+          node-version: '24'
       - name: Install pnpm
         uses: pnpm/action-setup@v4
       - name: Build documentation and Check Output

--- a/.github/workflows/refresh-asset-bundles.yml
+++ b/.github/workflows/refresh-asset-bundles.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
-        node-version: 22
+        node-version: 24
         cache: 'pnpm'
 
     - name: Install and build packages

--- a/.github/workflows/refresh-docker-cache.yml
+++ b/.github/workflows/refresh-docker-cache.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
-        node-version: 22
+        node-version: 24
         cache: 'pnpm'
 
     # we login to docker to avoid docker pull limit rates


### PR DESCRIPTION
This PR makes the following changes:
- add `id-token: write` permission to jobs that call `npm publish`
- limit permissions on each job in publish workflows to only those needed.
- remove auth token env vars
- use node 24 as default version (needed in publish jobs to get npm version >= 11.5.1)