### PR TITLE
Add log artifacts to test jobs

### DIFF
--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -52,6 +52,7 @@ jobs:
             docker-images-
       - run: pnpm test:all
       - name: Get Commit Short SHA
+        if: always()
         id: get-short-sha
         run: |
           calculatedSha=$(git rev-parse --short ${{ github.event.pull_request.head.sha || github.sha }})
@@ -69,6 +70,14 @@ jobs:
           name: teraslice-test-asset-${{ matrix.node-version }}-dev.${{ steps.get-short-sha.outputs.COMMIT_SHORT_SHA }}
           path: ./build
           retention-days: 7
+      - name: Upload logs artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs.commit-${{ steps.get-short-sha.outputs.COMMIT_SHORT_SHA }}.job-${{ github.job }}.node-${{ matrix.node-version }}
+          path: ./logs/*.log
+          retention-days: 3
+          if-no-files-found: ignore
 
   test-e2e:
     runs-on: ubuntu-latest
@@ -108,7 +117,20 @@ jobs:
             docker-images-
       - name: Install teraslice-cli
         run: npm install -g teraslice-cli
+      - name: Get Commit Short SHA
+        id: get-short-sha
+        run: |
+          calculatedSha=$(git rev-parse --short ${{ github.event.pull_request.head.sha || github.sha }})
+          echo "COMMIT_SHORT_SHA=$calculatedSha" >> $GITHUB_OUTPUT
       - run: pnpm test:e2e
+      - name: Upload logs artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs.commit-${{ steps.get-short-sha.outputs.COMMIT_SHORT_SHA }}.job-${{ github.job }}.node-${{ matrix.node-version }}
+          path: ./logs/*.log
+          retention-days: 3
+          if-no-files-found: ignore
 
   test-linux-encrypted:
     runs-on: ubuntu-latest
@@ -151,7 +173,20 @@ jobs:
         run: curl -Ss -JLO "https://dl.filippo.io/mkcert/v1.4.4?for=linux/amd64" && sudo chmod 777 mkcert-v1.4.4-linux-amd64 && sudo cp mkcert-v1.4.4-linux-amd64 /usr/local/bin/mkcert
       - name: Check mkcert
         run: command -v mkcert
+      - name: Get Commit Short SHA
+        id: get-short-sha
+        run: |
+          calculatedSha=$(git rev-parse --short ${{ github.event.pull_request.head.sha || github.sha }})
+          echo "COMMIT_SHORT_SHA=$calculatedSha" >> $GITHUB_OUTPUT
       - run: pnpm test:encrypted
+      - name: Upload logs artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs.commit-${{ steps.get-short-sha.outputs.COMMIT_SHORT_SHA }}.job-${{ github.job }}.node-${{ matrix.node-version }}
+          path: ./logs/*.log
+          retention-days: 3
+          if-no-files-found: ignore
 
   test-macos:
     runs-on: macos-latest

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -52,7 +52,7 @@ jobs:
             docker-images-
       - run: pnpm test:all
       - name: Get Commit Short SHA
-        if: always()
+        if: success() || failure()
         id: get-short-sha
         run: |
           calculatedSha=$(git rev-parse --short ${{ github.event.pull_request.head.sha || github.sha }})
@@ -71,7 +71,7 @@ jobs:
           path: ./build
           retention-days: 7
       - name: Upload logs artifact
-        if: always()
+        if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
           name: logs.commit-${{ steps.get-short-sha.outputs.COMMIT_SHORT_SHA }}.job-${{ github.job }}.node-${{ matrix.node-version }}
@@ -124,7 +124,7 @@ jobs:
           echo "COMMIT_SHORT_SHA=$calculatedSha" >> $GITHUB_OUTPUT
       - run: pnpm test:e2e
       - name: Upload logs artifact
-        if: always()
+        if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
           name: logs.commit-${{ steps.get-short-sha.outputs.COMMIT_SHORT_SHA }}.job-${{ github.job }}.node-${{ matrix.node-version }}
@@ -180,7 +180,7 @@ jobs:
           echo "COMMIT_SHORT_SHA=$calculatedSha" >> $GITHUB_OUTPUT
       - run: pnpm test:encrypted
       - name: Upload logs artifact
-        if: always()
+        if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
           name: logs.commit-${{ steps.get-short-sha.outputs.COMMIT_SHORT_SHA }}.job-${{ github.job }}.node-${{ matrix.node-version }}

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -50,13 +50,12 @@ jobs:
           restore-keys: |
             docker-images-${{ hashFiles('./images/image-list.txt') }}-
             docker-images-
-      - run: pnpm test:all
       - name: Get Commit Short SHA
-        if: success() || failure()
         id: get-short-sha
         run: |
           calculatedSha=$(git rev-parse --short ${{ github.event.pull_request.head.sha || github.sha }})
           echo "COMMIT_SHORT_SHA=$calculatedSha" >> $GITHUB_OUTPUT
+      - run: pnpm test:all
       - name: Append dev tag to version
         run: |
           jq '.version += "-dev.${{ steps.get-short-sha.outputs.COMMIT_SHORT_SHA }}"' asset/asset.json > tempAsset.json && mv tempAsset.json asset/asset.json

--- a/.github/workflows/prerelease-asset-test.yml
+++ b/.github/workflows/prerelease-asset-test.yml
@@ -52,6 +52,7 @@ jobs:
             docker-images-
       - run: pnpm test:all
       - name: Get Commit Short SHA
+        if: always()
         id: get-short-sha
         run: |
           calculatedSha=$(git rev-parse --short ${{ github.event.pull_request.head.sha || github.sha }})
@@ -69,6 +70,14 @@ jobs:
           name: teraslice-test-asset-${{ matrix.node-version }}-dev.${{ steps.get-short-sha.outputs.COMMIT_SHORT_SHA }}
           path: ./build
           retention-days: 7
+      - name: Upload logs artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs.commit-${{ steps.get-short-sha.outputs.COMMIT_SHORT_SHA }}.job-${{ github.job }}.node-${{ matrix.node-version }}
+          path: ./logs/*.log
+          retention-days: 3
+          if-no-files-found: ignore
 
   test-e2e:
     runs-on: ubuntu-latest
@@ -108,7 +117,20 @@ jobs:
             docker-images-
       - name: Install teraslice-cli
         run: npm install -g teraslice-cli@prerelease
+      - name: Get Commit Short SHA
+        id: get-short-sha
+        run: |
+          calculatedSha=$(git rev-parse --short ${{ github.event.pull_request.head.sha || github.sha }})
+          echo "COMMIT_SHORT_SHA=$calculatedSha" >> $GITHUB_OUTPUT
       - run: pnpm test:e2e
+      - name: Upload logs artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs.commit-${{ steps.get-short-sha.outputs.COMMIT_SHORT_SHA }}.job-${{ github.job }}.node-${{ matrix.node-version }}
+          path: ./logs/*.log
+          retention-days: 3
+          if-no-files-found: ignore
 
   test-macos:
     runs-on: macos-latest

--- a/.github/workflows/prerelease-asset-test.yml
+++ b/.github/workflows/prerelease-asset-test.yml
@@ -50,13 +50,12 @@ jobs:
           restore-keys: |
             docker-images-${{ hashFiles('./images/image-list.txt') }}-
             docker-images-
-      - run: pnpm test:all
       - name: Get Commit Short SHA
-        if: success() || failure()
         id: get-short-sha
         run: |
           calculatedSha=$(git rev-parse --short ${{ github.event.pull_request.head.sha || github.sha }})
           echo "COMMIT_SHORT_SHA=$calculatedSha" >> $GITHUB_OUTPUT
+      - run: pnpm test:all
       - name: Append dev tag to version
         run: |
           jq '.version += "-dev.${{ steps.get-short-sha.outputs.COMMIT_SHORT_SHA }}"' asset/asset.json > tempAsset.json && mv tempAsset.json asset/asset.json

--- a/.github/workflows/prerelease-asset-test.yml
+++ b/.github/workflows/prerelease-asset-test.yml
@@ -52,7 +52,7 @@ jobs:
             docker-images-
       - run: pnpm test:all
       - name: Get Commit Short SHA
-        if: always()
+        if: success() || failure()
         id: get-short-sha
         run: |
           calculatedSha=$(git rev-parse --short ${{ github.event.pull_request.head.sha || github.sha }})
@@ -71,7 +71,7 @@ jobs:
           path: ./build
           retention-days: 7
       - name: Upload logs artifact
-        if: always()
+        if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
           name: logs.commit-${{ steps.get-short-sha.outputs.COMMIT_SHORT_SHA }}.job-${{ github.job }}.node-${{ matrix.node-version }}
@@ -124,7 +124,63 @@ jobs:
           echo "COMMIT_SHORT_SHA=$calculatedSha" >> $GITHUB_OUTPUT
       - run: pnpm test:e2e
       - name: Upload logs artifact
-        if: always()
+        if: success() || failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs.commit-${{ steps.get-short-sha.outputs.COMMIT_SHORT_SHA }}.job-${{ github.job }}.node-${{ matrix.node-version }}
+          path: ./logs/*.log
+          retention-days: 3
+          if-no-files-found: ignore
+
+  test-linux-encrypted:
+    runs-on: ubuntu-latest
+    needs: cache-docker-images
+    strategy:
+      matrix:
+        # NOTE: Hard Coded Node Version array, should match array in build-and-publish-asset.yml
+        node-version: [22, 24]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+      # we login to docker to avoid docker pull limit rates
+      # secrets are now duplicated for Actions and Dependabot
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - run: pnpm install && pnpm run setup
+      - run: pnpm lint
+      - name: Create Docker Image List
+        run: |
+          pnpm docker:listImages
+          cat ./images/image-list.txt
+      - name: Restore Docker image cache
+        id: docker-cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/docker_cache
+          key: docker-images-${{ hashFiles('./images/image-list.txt') }}-master
+          restore-keys: |
+            docker-images-${{ hashFiles('./images/image-list.txt') }}-
+            docker-images-
+      - name: Install mkcert
+        run: curl -Ss -JLO "https://dl.filippo.io/mkcert/v1.4.4?for=linux/amd64" && sudo chmod 777 mkcert-v1.4.4-linux-amd64 && sudo cp mkcert-v1.4.4-linux-amd64 /usr/local/bin/mkcert
+      - name: Check mkcert
+        run: command -v mkcert
+      - name: Get Commit Short SHA
+        id: get-short-sha
+        run: |
+          calculatedSha=$(git rev-parse --short ${{ github.event.pull_request.head.sha || github.sha }})
+          echo "COMMIT_SHORT_SHA=$calculatedSha" >> $GITHUB_OUTPUT
+      - run: pnpm test:encrypted
+      - name: Upload logs artifact
+        if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
           name: logs.commit-${{ steps.get-short-sha.outputs.COMMIT_SHORT_SHA }}.job-${{ github.job }}.node-${{ matrix.node-version }}
@@ -228,7 +284,7 @@ jobs:
     secrets: inherit 
 
   all-tests-passed:
-    needs: [test-linux, test-e2e, test-macos, test-website]
+    needs: [test-linux, test-e2e, test-linux-encrypted, test-macos, test-website]
     runs-on: ubuntu-latest
     steps:
       - run: echo "All tests have passed"


### PR DESCRIPTION
This PR makes the following changes:

- Adds step to test CI jobs that bundles the log directory into a downloadable artifact.
  - Set to 3 days retention
  - Will not fail if logs aren't found 
  - Add e2e encrypted tests to pre-release test workflow