### PR TITLE
Add logging artifacts to workflows testing

### DIFF
--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -6,16 +6,28 @@ on:
 jobs:
   check-docker-limit-before:
     uses: ./.github/workflows/check-docker-limit.yml
-    secrets: inherit 
+    secrets: inherit
 
   cache-docker-images:
     needs: check-docker-limit-before
     uses: ./.github/workflows/cache-docker-images.yml
     secrets: inherit
 
+  compute-vars:
+    runs-on: ubuntu-latest
+    outputs:
+      COMMIT_SHORT_SHA: ${{ steps.get-short-sha.outputs.COMMIT_SHORT_SHA }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get Commit Short SHA
+        id: get-short-sha
+        run: |
+          calculatedSha=$(git rev-parse --short ${{ github.sha }})
+          echo "COMMIT_SHORT_SHA=$calculatedSha" >> $GITHUB_OUTPUT
+
   test-linux:
     runs-on: ubuntu-latest
-    needs: cache-docker-images
+    needs: [cache-docker-images, compute-vars]
     strategy:
       matrix:
         # NOTE: Hard Coded Node Version array, should match array in build-and-publish-asset.yml
@@ -51,14 +63,9 @@ jobs:
             docker-images-${{ hashFiles('./images/image-list.txt') }}-
             docker-images-
       - run: pnpm test:all
-      - name: Get Commit Short SHA
-        id: get-short-sha
-        run: |
-          calculatedSha=$(git rev-parse --short ${{ github.event.pull_request.head.sha || github.sha }})
-          echo "COMMIT_SHORT_SHA=$calculatedSha" >> $GITHUB_OUTPUT
       - name: Append dev tag to version
         run: |
-          jq '.version += "-dev.${{ steps.get-short-sha.outputs.COMMIT_SHORT_SHA }}"' asset/asset.json > tempAsset.json && mv tempAsset.json asset/asset.json
+          jq '.version += "-dev.${{ needs.compute-vars.outputs.COMMIT_SHORT_SHA }}"' asset/asset.json > tempAsset.json && mv tempAsset.json asset/asset.json
           cat asset/asset.json
       - run: pnpm dlx teraslice-cli -v
       - run: pnpm dlx teraslice-cli assets build
@@ -66,13 +73,20 @@ jobs:
       - name: Archive test build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: teraslice-test-asset-${{ matrix.node-version }}-dev.${{ steps.get-short-sha.outputs.COMMIT_SHORT_SHA }}
+          name: teraslice-test-asset-${{ matrix.node-version }}-dev.${{ needs.compute-vars.outputs.COMMIT_SHORT_SHA }}
           path: ./build
           retention-days: 7
+      - name: Upload logs artifact
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs.commit-${{ needs.compute-vars.outputs.COMMIT_SHORT_SHA }}.job-${{ github.job }}.node-${{ matrix.node-version }}
+          path: logs/*.log
+          retention-days: 3
 
   test-e2e:
     runs-on: ubuntu-latest
-    needs: cache-docker-images
+    needs: [cache-docker-images, compute-vars]
     strategy:
       matrix:
         # NOTE: Hard Coded Node Version array, should match array in build-and-publish-asset.yml
@@ -109,10 +123,17 @@ jobs:
       - name: Install teraslice-cli
         run: npm install -g teraslice-cli
       - run: pnpm test:e2e
+      - name: Upload logs artifact
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs.commit-${{ needs.compute-vars.outputs.COMMIT_SHORT_SHA }}.job-${{ github.job }}.node-${{ matrix.node-version }}
+          path: logs/*.log
+          retention-days: 3
 
   test-linux-encrypted:
     runs-on: ubuntu-latest
-    needs: cache-docker-images
+    needs: [cache-docker-images, compute-vars]
     strategy:
       matrix:
         # NOTE: Hard Coded Node Version array, should match array in build-and-publish-asset.yml
@@ -152,6 +173,13 @@ jobs:
       - name: Check mkcert
         run: command -v mkcert
       - run: pnpm test:encrypted
+      - name: Upload logs artifact
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs.commit-${{ needs.compute-vars.outputs.COMMIT_SHORT_SHA }}.job-${{ github.job }}.node-${{ matrix.node-version }}
+          path: logs/*.log
+          retention-days: 3
 
   test-macos:
     runs-on: macos-latest

--- a/.github/workflows/prerelease-asset-test.yml
+++ b/.github/workflows/prerelease-asset-test.yml
@@ -6,16 +6,28 @@ on:
 jobs:
   check-docker-limit-before:
     uses: ./.github/workflows/check-docker-limit.yml
-    secrets: inherit 
+    secrets: inherit
 
   cache-docker-images:
     needs: check-docker-limit-before
     uses: ./.github/workflows/cache-docker-images.yml
     secrets: inherit
 
+  compute-vars:
+    runs-on: ubuntu-latest
+    outputs:
+      COMMIT_SHORT_SHA: ${{ steps.get-short-sha.outputs.COMMIT_SHORT_SHA }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get Commit Short SHA
+        id: get-short-sha
+        run: |
+          calculatedSha=$(git rev-parse --short ${{ github.sha }})
+          echo "COMMIT_SHORT_SHA=$calculatedSha" >> $GITHUB_OUTPUT
+
   test-linux:
     runs-on: ubuntu-latest
-    needs: cache-docker-images
+    needs: [cache-docker-images, compute-vars]
     strategy:
       matrix:
         # NOTE: Hard Coded Node Version array, should match array in build-and-publish-asset.yml
@@ -51,14 +63,9 @@ jobs:
             docker-images-${{ hashFiles('./images/image-list.txt') }}-
             docker-images-
       - run: pnpm test:all
-      - name: Get Commit Short SHA
-        id: get-short-sha
-        run: |
-          calculatedSha=$(git rev-parse --short ${{ github.event.pull_request.head.sha || github.sha }})
-          echo "COMMIT_SHORT_SHA=$calculatedSha" >> $GITHUB_OUTPUT
       - name: Append dev tag to version
         run: |
-          jq '.version += "-dev.${{ steps.get-short-sha.outputs.COMMIT_SHORT_SHA }}"' asset/asset.json > tempAsset.json && mv tempAsset.json asset/asset.json
+          jq '.version += "-dev.${{ needs.compute-vars.outputs.COMMIT_SHORT_SHA }}"' asset/asset.json > tempAsset.json && mv tempAsset.json asset/asset.json
           cat asset/asset.json
       - run: pnpm dlx teraslice-cli@prerelease -v
       - run: pnpm dlx teraslice-cli@prerelease assets build
@@ -66,13 +73,20 @@ jobs:
       - name: Archive test build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: teraslice-test-asset-${{ matrix.node-version }}-dev.${{ steps.get-short-sha.outputs.COMMIT_SHORT_SHA }}
+          name: teraslice-test-asset-${{ matrix.node-version }}-dev.${{ needs.compute-vars.outputs.COMMIT_SHORT_SHA }}
           path: ./build
           retention-days: 7
+      - name: Upload logs artifact
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs.commit-${{ needs.compute-vars.outputs.COMMIT_SHORT_SHA }}.job-${{ github.job }}.node-${{ matrix.node-version }}
+          path: logs/*.log
+          retention-days: 3
 
   test-e2e:
     runs-on: ubuntu-latest
-    needs: cache-docker-images
+    needs: [cache-docker-images, compute-vars]
     strategy:
       matrix:
         # NOTE: Hard Coded Node Version array, should match array in build-and-publish-asset.yml
@@ -109,6 +123,13 @@ jobs:
       - name: Install teraslice-cli
         run: npm install -g teraslice-cli@prerelease
       - run: pnpm test:e2e
+      - name: Upload logs artifact
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs.commit-${{ needs.compute-vars.outputs.COMMIT_SHORT_SHA }}.job-${{ github.job }}.node-${{ matrix.node-version }}
+          path: logs/*.log
+          retention-days: 3
 
   test-macos:
     runs-on: macos-latest


### PR DESCRIPTION
This PR makes the following changes: 

- Adds logging artifacts to all test jobs
  - If a test doesn't produce any log files within the directory it will just no-op