### PR TITLE
publish to npm on package bump only

### DIFF
--- a/.github/workflows/asset-build-and-publish.yml
+++ b/.github/workflows/asset-build-and-publish.yml
@@ -12,21 +12,24 @@ on:
   workflow_call:
 
 jobs:
-  # Asset build, publish and release will only occur if the current asset version 
+  # Asset build will occur if any versions are updated
+  # NPM publish will occur if a public sub-package version has updated
+  # Asset release will occur if the current asset version 
   # is greater than the latest release or pre-release version
   version-check:
     runs-on: ubuntu-latest
     permissions:
       contents: read
     outputs:
-      version_updated: ${{ steps.version_check.outputs.version_updated}}
-      tag: ${{ steps.version_check.outputs.tag}}
+      asset_version_updated: ${{ steps.asset_version_check.outputs.asset_version_updated}}
+      package_version_updated: ${{ steps.package_version_check.outputs.package_version_updated}}
+      tag: ${{ steps.asset_version_check.outputs.tag}}
     steps:
       - name: Check out code
         uses: actions/checkout@v6
       
       - name: Check for asset version update
-        id: version_check
+        id: asset_version_check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -41,17 +44,41 @@ jobs:
 
           if [[ "$COMP_OUTPUT" = "1" ]]; then
             echo "Asset version updated from $LATEST_RELEASE_VERSION to $CURRENT_VERSION, creating release"
-            echo "version_updated=true" >> $GITHUB_OUTPUT
+            echo "asset_version_updated=true" >> $GITHUB_OUTPUT
             echo "tag: v$CURRENT_VERSION"
             echo "tag=v$CURRENT_VERSION" >> $GITHUB_OUTPUT
           else
             echo "Asset version not updated, will not release"
-            echo "version_updated=false" >> $GITHUB_OUTPUT
+            echo "asset_version_updated=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check for package version updates
+        id: package_version_check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pnpm publish -r --dry-run --report-summary
+
+          if [ ! -f pnpm-publish-summary.json ]; then
+            echo "No publish summary found, skipping"
+            echo "package_version_updated=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          TO_BE_PUBLISHED=$(jq -r '.publishedPackages[] | "\(.name)@\(.version)"' pnpm-publish-summary.json)
+
+          if [ -n "$TO_BE_PUBLISHED" ]; then
+            echo "Packages being updated:"
+            echo "$TO_BE_PUBLISHED"
+            echo "package_version_updated=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No packages to publish"
+            echo "package_version_updated=false" >> "$GITHUB_OUTPUT"
           fi
 
   asset-build:
     needs: [version-check]
-    if: needs.version-check.outputs.version_updated == 'true'
+    if: needs.version-check.outputs.asset_version_updated == 'true' || needs.version-check.outputs.package_version_updated == 'true' 
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -82,14 +109,13 @@ jobs:
           name: teraslice-asset-${{ matrix.node-version }}
           path: ./build
 
-  # Asset Release and NPM Publish should be done only after builds from all Node
-  # versions have completed.
-  asset-publish-and-release:
+  # NPM Publish should be done only after builds from all Node versions have completed.
+  npm-publish:
     needs: [version-check, asset-build]
+    if: needs.version-check.outputs.package_version_updated == 'true'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-      contents: write
     steps:
       - uses: actions/checkout@v6
 
@@ -105,6 +131,23 @@ jobs:
 
       - run: pnpm publish -r --no-git-checks
 
+  # Asset Release should be done only after builds from all Node versions have completed.
+  asset-release:
+    needs: [version-check, asset-build]
+    if: needs.version-check.outputs.asset_version_updated == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          # NOTE: Hard Coded Node Version
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+      
       - name: Download assets from Teraslice Asset Build
         uses: actions/download-artifact@v8
         with:
@@ -172,7 +215,7 @@ jobs:
   build-docs:
     runs-on: ubuntu-latest
     needs: [version-check, check-for-website]
-    if: needs.version-check.outputs.version_updated == 'true' && needs.check-for-website.outputs.website_exists == 'true'
+    if: needs.version-check.outputs.asset_version_updated == 'true' && needs.check-for-website.outputs.website_exists == 'true'
     permissions:
       contents: read
     steps:

--- a/.github/workflows/asset-build-and-publish.yml
+++ b/.github/workflows/asset-build-and-publish.yml
@@ -215,7 +215,7 @@ jobs:
   build-docs:
     runs-on: ubuntu-latest
     needs: [version-check, check-for-website]
-    if: needs.version-check.outputs.asset_version_updated == 'true' && needs.check-for-website.outputs.website_exists == 'true'
+    if: (needs.version-check.outputs.asset_version_updated == 'true' || needs.version-check.outputs.package_version_updated == 'true') && needs.check-for-website.outputs.website_exists == 'true'
     permissions:
       contents: read
     steps:

--- a/.github/workflows/prerelease-asset-build-and-publish.yml
+++ b/.github/workflows/prerelease-asset-build-and-publish.yml
@@ -14,21 +14,24 @@ on:
   workflow_call:
 
 jobs:
-  # Asset build, publish and release will only occur if the current asset version 
-  # is a prerelease and is greater than the latest release or pre-release version
+  # Asset build will occur if any versions are updated
+  # NPM publish will occur if a public sub-package version has updated
+  # Asset release will occur if the current asset version 
+  # is greater than the latest release or pre-release version
   version-check:
     runs-on: ubuntu-latest
     permissions:
       contents: read
     outputs:
-      version_updated: ${{ steps.version_check.outputs.version_updated}}
-      tag: ${{ steps.version_check.outputs.tag}}
+      asset_version_updated: ${{ steps.asset_version_check.outputs.asset_version_updated}}
+      package_version_updated: ${{ steps.package_version_check.outputs.package_version_updated}}
+      tag: ${{ steps.asset_version_check.outputs.tag}}
     steps:
       - name: Check out code
         uses: actions/checkout@v6
       
       - name: Check for asset version update
-        id: version_check
+        id: asset_version_check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -47,17 +50,40 @@ jobs:
           
           if [[ "$COMP_OUTPUT" = "1" && "$IS_PRE_RELEASE" = "true" ]]; then
             echo "Asset version updated from $LATEST_RELEASE_VERSION to $CURRENT_VERSION, creating release"
-            echo "version_updated=true" >> $GITHUB_OUTPUT
+            echo "asset_version_updated=true" >> $GITHUB_OUTPUT
             echo "tag: v$CURRENT_VERSION"
             echo "tag=v$CURRENT_VERSION" >> $GITHUB_OUTPUT
           else
             echo "Asset pre-release version not updated, will not release"
-            echo "version_updated=false" >> $GITHUB_OUTPUT
+            echo "asset_version_updated=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Check for package version updates
+        id: package_version_check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pnpm publish -r --tag prerelease --dry-run --report-summary
+
+          if [ ! -f pnpm-publish-summary.json ]; then
+            echo "No publish summary found, skipping"
+            echo "package_version_updated=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          TO_BE_PUBLISHED=$(jq -r '.publishedPackages[] | "\(.name)@\(.version)"' pnpm-publish-summary.json)
+
+          if [ -n "$TO_BE_PUBLISHED" ]; then
+            echo "Packages being updated:"
+            echo "$TO_BE_PUBLISHED"
+            echo "package_version_updated=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No packages to publish"
+            echo "package_version_updated=false" >> "$GITHUB_OUTPUT"
+          fi
   asset-build:
     needs: [version-check]
-    if: needs.version-check.outputs.version_updated == 'true'
+    if: needs.version-check.outputs.asset_version_updated == 'true' || needs.version-check.outputs.package_version_updated == 'true' 
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -88,14 +114,13 @@ jobs:
           name: teraslice-asset-${{ matrix.node-version }}
           path: ./build
 
-  # Asset Release and NPM Publish should be done only after builds from all Node
-  # versions have completed.
-  asset-publish-and-release:
+  # NPM Publish should be done only after builds from all Node versions have completed.
+  npm-publish:
     needs: [version-check, asset-build]
+    if: needs.version-check.outputs.package_version_updated == 'true'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-      contents: write
     steps:
       - uses: actions/checkout@v6
 
@@ -111,6 +136,22 @@ jobs:
 
       - run: pnpm publish -r --tag prerelease --no-git-checks
 
+   # Asset Release should be done only after builds from all Node versions have completed.
+  asset-release:
+    needs: [version-check, asset-build]
+    if: needs.version-check.outputs.asset_version_updated == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          # NOTE: Hard Coded Node Version
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
       - name: Download assets from Teraslice Asset Build
         uses: actions/download-artifact@v8
         with:


### PR DESCRIPTION
This PR makes the following changes:
- check for package version changes in asset publish and release pipelines.
- split npm publish into a separate job that runs if a package version has updated, even if the asset was not bumped.