### PR TITLE
install pnpm on version-check job

### DIFF
--- a/.github/workflows/asset-build-and-publish.yml
+++ b/.github/workflows/asset-build-and-publish.yml
@@ -27,6 +27,11 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      - run: pnpm install && pnpm run setup
       
       - name: Check for asset version update
         id: asset_version_check

--- a/.github/workflows/prerelease-asset-build-and-publish.yml
+++ b/.github/workflows/prerelease-asset-build-and-publish.yml
@@ -29,6 +29,11 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      - run: pnpm install && pnpm run setup
       
       - name: Check for asset version update
         id: asset_version_check


### PR DESCRIPTION
This PR fixes an error in `version-check` where pnpm was not installed.