### PR TITLE
workflows should check for master or main branch

### DIFF
--- a/.github/workflows/asset-build-and-publish.yml
+++ b/.github/workflows/asset-build-and-publish.yml
@@ -2,13 +2,13 @@
 # the branch has been tested.  The test-asset.yml should include:
 #   push:
 #     branches:
-#       - master
+#       - master/main
 #       - 'release/*-assets-v*'
 #   pull_request:
 #     branches:
-#       - master
+#       - master/main
 #       - 'release/*-assets-v*'
-# which is meant to test on PRs and pushes to master and release branches.
+# which is meant to test on PRs and pushes to master/main and release branches.
 
 name: Build, Publish and Release Teraslice Asset
 run-name: ${{ github.actor }} is building, publishing, and releasing the Teraslice Asset

--- a/.github/workflows/asset-test.yml
+++ b/.github/workflows/asset-test.yml
@@ -325,7 +325,7 @@ jobs:
           find ./website/build
 
   comment-artifact-urls:
-    # skip comment on push event (merge to master) and dependabot PRs
+    # skip comment on push event (merge to master/main) and dependabot PRs
     if: github.event_name != 'push' && github.actor != 'dependabot[bot]'
     needs: [test-linux, test-macos, test-linux-encrypted, test-e2e]
     runs-on: ubuntu-latest

--- a/.github/workflows/refresh-asset-bundles.yml
+++ b/.github/workflows/refresh-asset-bundles.yml
@@ -12,8 +12,8 @@ jobs:
       contents: read
       actions: write
 
-    # # final check to make sure it runs only on master branch
-    if: github.ref == 'refs/heads/master'
+    # # final check to make sure it runs only on master/main branch
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
 
     steps:
     - name: Check out code
@@ -56,7 +56,7 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         REPO: ${{ github.repository }}
-        BRANCH: refs/heads/master
+        BRANCH: ${{ github.ref }}
       run: |
         gh extension install actions/gh-actions-cache
 

--- a/.github/workflows/refresh-docker-cache.yml
+++ b/.github/workflows/refresh-docker-cache.yml
@@ -26,8 +26,8 @@ jobs:
       contents: read
       actions: write
 
-    # # final check to make sure it runs only on master branch
-    if: github.ref == 'refs/heads/master'
+    # # final check to make sure it runs only on master/main branch
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
 
     steps:
     - name: Check out code
@@ -72,7 +72,7 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         REPO: ${{ github.repository }}
-        BRANCH: refs/heads/master
+        BRANCH: ${{ github.ref }}
       run: |
         gh extension install actions/gh-actions-cache
 


### PR DESCRIPTION
Some of these workflows are now used by repos that have a main branch, so we need to check for either master or main.